### PR TITLE
Fix menu helper text rendering on Cardputer

### DIFF
--- a/idol_natsumi_v0.6.1005/idol_natsumi_v0.6.1005.ino
+++ b/idol_natsumi_v0.6.1005/idol_natsumi_v0.6.1005.ino
@@ -660,9 +660,12 @@ void drawMenu(const char* items[], int itemCount, int selection) {
     M5Cardputer.Display.println(items[i]);
   }
 
-  M5Cardputer.Display.setTextColor(0x7BEF);
+  // Helper text at the bottom
+  M5Cardputer.Display.setTextSize(1); // smallest size
+  M5Cardputer.Display.setTextColor(WHITE, BLACK);
+  M5Cardputer.Display.fillRect(0, 115, 240, M5Cardputer.Display.fontHeight(), BLACK);
   M5Cardputer.Display.setCursor(10, 115);
-  M5Cardputer.Display.println("↑/↓: Navigate, ENTER: Validate");
+  M5Cardputer.Display.print("\x18/\x19: Navigate, ENTER: Validate");
 }
 
 void drawDevSCreen() {


### PR DESCRIPTION
## Summary
- Draw menu helper in smallest font with white on black background
- Replace Unicode arrows with displayable characters for Cardputer

## Testing
- `arduino-cli version` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*
- `g++ -fsyntax-only /tmp/main.cpp` *(fails: M5Cardputer.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa625f50588321bc6dc10a1f544fcb