### PR TITLE
Refactor drawBackground to accept image buffer parameter

### DIFF
--- a/idol_natsumi_v0.6.1006/idol_natsumi_v0.6.1006.ino
+++ b/idol_natsumi_v0.6.1006/idol_natsumi_v0.6.1006.ino
@@ -305,7 +305,7 @@ void loop() {
       Menu: None
       Non-interactive (timer)
       */
-      drawBackground();
+      drawBackground(currentBackground);
       drawDebug();
       break;
     case DIALOG:
@@ -318,7 +318,7 @@ void loop() {
       Menu: None
       Interactive (timer + keypress + escape)
       */
-      drawBackground();
+      drawBackground(currentBackground);
       drawCharacter();
       drawDebug();
       break;
@@ -358,7 +358,7 @@ void loop() {
       Menu: Yes
       Interactive (timer + keypress + escape)
       */
-      drawBackground();
+      drawBackground(currentBackground);
       drawCharacter();
       drawDebug();
       drawToast();
@@ -807,9 +807,9 @@ void rest() {
   fgNeedsRedraw = false;
 }
 
-void drawBackground() {
+void drawBackground(const ImageBuffer& bg) {
   // Draw the background of the screen (layer 0)
-  drawImage(currentBackground);
+  drawImage(bg);
 }
 
 void drawCharacter() {


### PR DESCRIPTION
## Summary
- Refactor `drawBackground` to accept an `ImageBuffer` argument instead of using global state
- Update all callers to pass `currentBackground`

## Testing
- `g++ -x c++ -c idol_natsumi_v0.6.1006/idol_natsumi_v0.6.1006.ino -o /tmp/out.o` *(fails: M5Cardputer.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a1d0de30832199ab229a5e6157c3