### PR TITLE
Fix menu redraw condition in drawMenu

### DIFF
--- a/idol_natsumi_v0.6.1006/idol_natsumi_v0.6.1006.ino
+++ b/idol_natsumi_v0.6.1006/idol_natsumi_v0.6.1006.ino
@@ -776,7 +776,7 @@ void drawToast() {
 
 void drawMenu(String menuType, const char* items[], int itemCount, int selection) {
   // Draw menus on the screen (layer 4)
-  if (l4NeedsRedraw) || (M5Cardputer.Keyboard.isChange() && M5Cardputer.Keyboard.isPressed()) {
+  if (l4NeedsRedraw || (M5Cardputer.Keyboard.isChange() && M5Cardputer.Keyboard.isPressed())) {
     uint16_t overlayColor = M5Cardputer.Display.color888(30, 30, 30);
     int x = 60, y = 35, w = 120, h = 65;
 


### PR DESCRIPTION
## Summary
- ensure menu redraw check includes keyboard interaction

## Testing
- `g++ -x c++ -fsyntax-only idol_natsumi_v0.6.1006/idol_natsumi_v0.6.1006.ino` *(fails: M5Cardputer.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b65e87fbf4832188cbd9328ba708a0