### PR TITLE
Return after opening dev menu

### DIFF
--- a/idol_natsumi_v0.6.1006/idol_natsumi_v0.6.1006.ino
+++ b/idol_natsumi_v0.6.1006/idol_natsumi_v0.6.1006.ino
@@ -899,7 +899,7 @@ void drawMenu(String menuType, const char* items[], int itemCount, int &selectio
         // 2: DEV SCREEN
         changeState(4, DEV_SCREEN);
         menuOpened = true;
-        break;
+        return;
       case 181: case 'w': case 'W': case 59:
         // UP
         selection = (selection - 1 + mainMenuItemCount) % mainMenuItemCount;
@@ -921,8 +921,9 @@ void drawMenu(String menuType, const char* items[], int itemCount, int &selectio
         } else {
           changeState(4, DEV_SCREEN);
           menuOpened = true;
+          return;
         }
-        break;
+        
     }
   }
 


### PR DESCRIPTION
## Summary
- return from drawMenu after selecting the developer screen via key or validation to prevent stale overlay

## Testing
- `g++ -x c++ -fsyntax-only idol_natsumi_v0.6.1006/idol_natsumi_v0.6.1006.ino` *(fails: M5Cardputer.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a90b6a888321a547f47bbb1ef9e0