### PR TITLE
Ensure home helper banner redraws when menu closes

### DIFF
--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -1092,6 +1092,7 @@ void drawMenu(String menuType, const char* items[], int itemCount, int &selectio
         // TAB
         if (menuOpened) {
           menuOpened = false;
+          helperNeedsRedraw = true;
           l0NeedsRedraw = true;
           changeState(0, HOME_LOOP, 0);
         } else {
@@ -1103,6 +1104,7 @@ void drawMenu(String menuType, const char* items[], int itemCount, int &selectio
         // ESC
         if (menuOpened) {
           menuOpened = false;
+          helperNeedsRedraw = true;
           l0NeedsRedraw = true;
           changeState(0, HOME_LOOP, 0);
         }
@@ -1142,6 +1144,7 @@ void drawMenu(String menuType, const char* items[], int itemCount, int &selectio
             debugEnabled = true;
             l2NeedsRedraw = true;
           }
+          helperNeedsRedraw = true;
         }
         menuOpened = false;
         break;

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -855,13 +855,6 @@ void manageRoom() {
   drawCharacter();
   drawDebug();
   drawToast();
-  if (helperNeedsRedraw) {
-    // Helper text at the bottom
-    Serial.println("[DEBUG] manageHomeScreen() -> helperNeedsRedraw TRUE");
-    M5Cardputer.Display.fillRect(0, 125, 240, 10, BLACK);
-    drawText("TAB: Open menu", 120, 131, true, WHITE, 1);
-    helperNeedsRedraw = false;
-  }
 
   int *selectionPtr;
   if (currentMenuType == "home") {
@@ -872,6 +865,14 @@ void manageRoom() {
     selectionPtr = &mainMenuSelection;
   }
   drawMenu(currentMenuType, currentMenuItems, currentMenuItemsCount, *selectionPtr);
+
+  if (helperNeedsRedraw && !menuOpened) {
+    // Helper text at the bottom
+    Serial.println("[DEBUG] manageHomeScreen() -> helperNeedsRedraw TRUE");
+    M5Cardputer.Display.fillRect(0, 125, 240, 10, BLACK);
+    drawText("TAB: Open menu", 120, 131, true, WHITE, 1);
+    helperNeedsRedraw = false;
+  }
 }
 
 void manageText() {
@@ -989,6 +990,7 @@ void drawCharacter() {
     l2NeedsRedraw = true;
     l3NeedsRedraw = true;
     l4NeedsRedraw = true;
+    helperNeedsRedraw = true;
   }
 }
 
@@ -1025,7 +1027,6 @@ void drawToast() {
       toastActive = false;
       l0NeedsRedraw = true;
       l3NeedsRedraw = false;
-      helperNeedsRedraw = true;
     }
   }
   if (l3NeedsRedraw && toastActive) {


### PR DESCRIPTION
## Summary
- mark the helper banner for redraw whenever the home menu closes via Tab/Esc or the Debug option
- revert the earlier main-menu-specific Tab/Esc handling that was unrelated to the issue

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911b4c4b764832182348bafa31acd84)