### PR TITLE
Add nap energy overlay

### DIFF
--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -1056,7 +1056,7 @@ void drawNapEnergyOverlay() {
 
 void nap() {
   uint8_t key = 0;
-  if (l5NeedsRedraw || lastNapEnergyDisplayed != natsumi.energy) {
+  if ((l5NeedsRedraw || lastNapEnergyDisplayed != natsumi.energy) && natsumi.energy < 4) {
     drawNapEnergyOverlay();
     lastNapEnergyDisplayed = natsumi.energy;
     l5NeedsRedraw = false;

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -811,7 +811,8 @@ void manageGame() {
   */
   switch (currentState) {
     case STATS_SCREEN:
-      manageStats();
+      // manageStats();
+      // l5NeedsRedraw = true;
       break;
     default:
       playGame();
@@ -824,6 +825,7 @@ void manageGame() {
 
   // Draw required layers for GAME screens
   drawDebug();
+  drawOverlay();
 }
 
 void manageIdle() {
@@ -924,14 +926,6 @@ void manageRoom() {
     selectionPtr = &mainMenuSelection;
   }
   drawMenu(currentMenuType, currentMenuItems, currentMenuItemsCount, *selectionPtr);
-
-  if (l5NeedsRedraw && !menuOpened) {
-    // Helper text at the bottom
-    Serial.println("[DEBUG] manageHomeScreen() -> l5NeedsRedraw TRUE");
-    M5Cardputer.Display.fillRect(0, 125, 240, 10, BLACK);
-    drawText("TAB: Open menu", 120, 131, true, WHITE, 1);
-    l5NeedsRedraw = false;
-  }
 }
 
 void manageText() {
@@ -1855,12 +1849,22 @@ void drawMenu(String menuType, const char* items[], int itemCount, int &selectio
 
 void drawOverlay() {
   // Draw the overlay (L5)
-  Serial.println("> Entering drawOverlay() L5 with l5NeedsRedraw set to " + String(l5NeedsRedraw));
+  Serial.println("> Entering drawOverlay() L5 with l5NeedsRedraw set to " + String(l5NeedsRedraw) + " and statsActive set to " + String(statsActive));
   if (l5NeedsRedraw) {
+    // Serial.println(">> l5NeedsRedraw is TRUE");
     switch (currentState) {
       case HOME_LOOP:
+        if (!menuOpened) {
+          // Helper text at the bottom
+          Serial.println("[DEBUG] manageHomeScreen() -> l5NeedsRedraw TRUE");
+          M5Cardputer.Display.fillRect(0, 125, 240, 10, BLACK);
+          drawText("TAB: Open menu", 120, 131, true, WHITE, 1);
+        }
+        break;
+      case STATS_SCREEN:
+        // Serial.println(">> Entering drawStats()");
         if (statsActive) {
-          drawStats();
+          manageStats();
         }
         break;
       case REST_NAP:
@@ -1884,7 +1888,7 @@ void drawStats() {
   Serial.println("> Entering drawStats()");
   static unsigned long lastDraw = 0;
   unsigned long now = millis();
-    if (now - lastDraw < 120 && (l0NeedsRedraw || l1NeedsRedraw || l3NeedsRedraw)) {
+  if (now - lastDraw < 120 && (l0NeedsRedraw || l1NeedsRedraw || l3NeedsRedraw)) {
     return;
   }
   lastDraw = now;
@@ -1946,9 +1950,11 @@ void drawStats() {
 
   M5Cardputer.Display.setTextDatum(top_left);
   M5Cardputer.Display.setTextSize(1);
+  Serial.println("> Exiting drawStats()");
 }
 
 void drawStatBar(const String &label, int value, int maxValue, int x, int y, int width, int barHeight, uint16_t barColor, uint16_t bgColor, uint16_t frameColor) {
+  Serial.println("> Entering drawStatBar()");
   if (maxValue <= 0) {
     maxValue = 1;
   }
@@ -2007,6 +2013,8 @@ void manageStats() {
       changeState(0, HOME_LOOP, 0);
       return;
     }
+  } else {
+    drawStats();
   }
 }
 

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -166,8 +166,6 @@ void showToast(const String& msg, unsigned long ms = longWait) {
   l3NeedsRedraw = true;
 }
 
-void drawNapEnergyOverlay();
-
 // === UI Helper Functions ===
 void drawText(String text, int x, int y, bool centerAlign, uint16_t color = WHITE, int textSize = 2, uint16_t bgColor = BLACK) {
     M5Cardputer.Display.setTextSize(textSize);

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -519,6 +519,7 @@ void changeState(int baseLayer, GameState targetState, int delay) {
         case STATS_SCREEN:
           screenConfig = GAME;
           statsActive = true;
+          l5NeedsRedraw = true;
           break;
         case FOOD_MENU:
           screenConfig = ROOM;
@@ -811,8 +812,7 @@ void manageGame() {
   */
   switch (currentState) {
     case STATS_SCREEN:
-      // manageStats();
-      // l5NeedsRedraw = true;
+      manageStats();
       break;
     default:
       playGame();
@@ -1851,7 +1851,7 @@ void drawOverlay() {
   // Draw the overlay (L5)
   Serial.println("> Entering drawOverlay() L5 with l5NeedsRedraw set to " + String(l5NeedsRedraw) + " and statsActive set to " + String(statsActive));
   if (l5NeedsRedraw) {
-    // Serial.println(">> l5NeedsRedraw is TRUE");
+    Serial.println(">> l5NeedsRedraw is TRUE");
     switch (currentState) {
       case HOME_LOOP:
         if (!menuOpened) {
@@ -1862,9 +1862,9 @@ void drawOverlay() {
         }
         break;
       case STATS_SCREEN:
-        // Serial.println(">> Entering drawStats()");
+        Serial.println(">> Entering drawStats()");
         if (statsActive) {
-          manageStats();
+          drawStats();
         }
         break;
       case REST_NAP:
@@ -2013,8 +2013,6 @@ void manageStats() {
       changeState(0, HOME_LOOP, 0);
       return;
     }
-  } else {
-    drawStats();
   }
 }
 

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -1047,9 +1047,11 @@ void drawNapEnergyOverlay() {
     startX += segmentWidth + segmentSpacing;
   }
 
+  /*
   drawText(String(natsumi.energy) + "/4", panelX + panelW - 45, panelY + panelH - 16, false, accentColor, 1, panelColor);
   drawText("tap any key to wake", panelX + panelW / 2, panelY + panelH - 12, true, borderColor, 1, panelColor);
   drawText("z z z", panelX + 20, panelY + panelH - 20, false, WHITE, 1, panelColor);
+  */
 }
 
 void nap() {
@@ -1868,7 +1870,9 @@ void drawOverlay() {
         }
         break;
       case REST_NAP:
-        drawNapEnergyOverlay();
+        if (natsumi.energy < 4) {
+          drawNapEnergyOverlay();
+        }
         break;
       default:
         break; 


### PR DESCRIPTION
## Summary
- add a redraw-aware overlay to show Natsumi's energy while resting
- track energy changes and trigger overlay updates during the nap state

## Testing
- not run (hardware-specific)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915a9876ec48321b79e2d818284d00e)