### PR TITLE
Add meditation timer overlay

### DIFF
--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -1146,7 +1146,7 @@ void drawMeditationOverlay() {
   float progress = meditateInterval == 0 ? 1.0f : (float)elapsed / (float)meditateInterval;
   if (progress > 1.0f) progress = 1.0f;
   
-  if ( lastMeditationDisplayed == 0 || lastMeditationDisplayed == 10 ) {
+  if ( lastMeditationDisplayed == 0 || lastMeditationDisplayed == 100 ) {
     lastMeditationDisplayed = 0;
     // Panel frame
     M5Cardputer.Display.fillRoundRect(panelX + 3, panelY + 4, panelW, panelH, 14, shadowColor);
@@ -1179,15 +1179,14 @@ void drawMeditationOverlay() {
       currentX += width + gap;
     }
     M5Cardputer.Display.drawRoundRect(barX - 1, barY - 1, barW + 2, barH + 2, 7, borderColor);
-  
-    if (remaining == 0) {
-      meditationActive = false;
-      if (!meditationRewardApplied) {
-        if (natsumi.spirit < 4 ) {
-          natsumi.spirit += 1;
-        }
-        meditationRewardApplied = true;
+  }
+  if (remaining == 0) {
+    meditationActive = false;
+    if (!meditationRewardApplied) {
+      if (natsumi.spirit < 4 ) {
+        natsumi.spirit += 1;
       }
+      meditationRewardApplied = true;
     }
   }
   lastMeditationDisplayed++;
@@ -2037,6 +2036,7 @@ void drawOverlay() {
         break;
       case REST_MEDITATE:
         Serial.println(">>> drawOverlay: REST_MEDITATE");
+        Serial.println(">>> drawOverlay: lastMeditationDisplayed=" + String(lastMeditationDisplayed));
         drawMeditationOverlay();
         break;
       default:

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -1100,12 +1100,6 @@ void drawNapEnergyOverlay() {
     }
     startX += segmentWidth + segmentSpacing;
   }
-
-  /*
-  drawText(String(natsumi.energy) + "/4", panelX + panelW - 45, panelY + panelH - 16, false, accentColor, 1, panelColor);
-  drawText("tap any key to wake", panelX + panelW / 2, panelY + panelH - 12, true, borderColor, 1, panelColor);
-  drawText("z z z", panelX + 20, panelY + panelH - 20, false, WHITE, 1, panelColor);
-  */
 }
 
 void drawMeditationOverlay() {
@@ -1121,18 +1115,11 @@ void drawMeditationOverlay() {
   const uint16_t accentMuted = M5Cardputer.Display.color565(40, 70, 110);
   const uint16_t textColor = WHITE;
 
-  // static unsigned long lastDraw = 0;
   unsigned long now = millis();
   unsigned long elapsed = (now >= meditateStart) ? (now - meditateStart) : 0;
   if (elapsed > meditateInterval) {
     elapsed = meditateInterval;
   }
-  /*
-  if (now - lastDraw < 120) {
-    return;
-  }
-  lastDraw = now;
-  */
 
   unsigned long remaining = (elapsed >= meditateInterval) ? 0 : (meditateInterval - elapsed);
   float progress = meditateInterval == 0 ? 1.0f : (float)elapsed / (float)meditateInterval;
@@ -1148,32 +1135,9 @@ void drawMeditationOverlay() {
   drawText("INNER CALM", panelX + panelW / 2, panelY + 14, true, borderColor, 1, panelColor);
   drawText("Meditation", panelX + panelW / 2, panelY + 30, true, textColor, 2, panelColor);
 
-  /*
-  // Countdown timer display
-  unsigned long remainingMinutes = remaining / 60000UL;
-  unsigned long remainingSeconds = (remaining / 1000UL) % 60UL;
-  String timeText = "";
-  if (remainingMinutes < 10) {
-    timeText += "0";
-  }
-  timeText += String(remainingMinutes);
-  timeText += ":";
-  if (remainingSeconds < 10) {
-    timeText += "0";
-  }
-  timeText += String(remainingSeconds);
-  drawText(timeText, panelX + panelW / 2, panelY + 52, true, accentColor, 3, panelColor);
-
-  // Breathing guidance
-  bool inhalePhase = ((elapsed / 1000UL) % 8UL) < 4UL;
-  String guidance = inhalePhase ? "Inhale gently" : "Exhale slowly";
-  drawText(guidance, panelX + panelW / 2, panelY + 72, true, borderColor, 1, panelColor);
-  */
-  
   // Progress bar made of soft segments
   const int barX = panelX + 24;
-  // const int barY = panelY + panelH - 32;
-  const int barY = panelY + panelH - 28;
+  const int barY = panelY + panelH - 30;
   const int barW = panelW - 48;
   const int barH = 14;
   const int segmentCount = 24;
@@ -1193,15 +1157,6 @@ void drawMeditationOverlay() {
   }
   M5Cardputer.Display.drawRoundRect(barX - 1, barY - 1, barW + 2, barH + 2, 7, borderColor);
 
-  /*
-  if (remaining == 0) {
-    drawText("Meditation complete", panelX + panelW / 2, panelY + panelH - 16, true, accentColor, 1, panelColor);
-    drawText("Press any key to return", panelX + panelW / 2, panelY + panelH - 4, true, textColor, 1, panelColor);
-  } else {
-    drawText("Stay present. Calm is growing", panelX + panelW / 2, panelY + panelH - 16, true, textColor, 1, panelColor);
-  }
-  */
-
   if (remaining == 0) {
     meditationActive = false;
     if (!meditationRewardApplied) {
@@ -1209,7 +1164,6 @@ void drawMeditationOverlay() {
         natsumi.spirit += 1;
       }
       meditationRewardApplied = true;
-      // showToast("Natsumi feels more centered");
     }
   }
 }
@@ -1243,12 +1197,10 @@ void meditate() {
     if (now - meditateStart >= meditateInterval) {
       meditationActive = false;
       l5NeedsRedraw = true;
-    } else if (now - lastMeditationRedraw >= 500) {
+    } else if (now - lastMeditationRedraw >= 1000) {
       l5NeedsRedraw = true;
       lastMeditationRedraw = now;
     }
-  } else if (!meditationRewardApplied) {
-    // l5NeedsRedraw = true;
   }
 
   bool meditationFinished = (!meditationActive && meditationRewardApplied);

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -1219,13 +1219,7 @@ void meditate() {
   unsigned long now = millis();
 
   if (meditationActive) {
-    if (now - meditateStart >= meditateInterval) {
-      meditationActive = false;
-      l5NeedsRedraw = true;
-    } else if (now - lastMeditationRedraw >= 1000) {
-      l5NeedsRedraw = true;
-      lastMeditationRedraw = now;
-    }
+    l5NeedsRedraw = true;
   }
 
   bool meditationFinished = (!meditationActive && meditationRewardApplied);
@@ -1240,7 +1234,7 @@ void meditate() {
 // === Draw functions ===
 void drawBackground(const ImageBuffer& bg) {
   // Draw the background of the screen (layer 0)
-  Serial.println("> Entering drawBackground() L0");
+  // Serial.println("> Entering drawBackground() L0");
   if (l0NeedsRedraw) {
     drawImage(bg);
     l0NeedsRedraw = false;
@@ -1254,7 +1248,7 @@ void drawBackground(const ImageBuffer& bg) {
 
 void drawCharacter() {
   // Draw the character(s) on the screen (layer 1)
-  Serial.println("> Entering drawCharacter() L1");
+  // Serial.println("> Entering drawCharacter() L1");
   if (l1NeedsRedraw) {
     drawImage(currentCharacter);
     l1NeedsRedraw = false;
@@ -1267,7 +1261,7 @@ void drawCharacter() {
 
 void drawDebug() {
   // Draw debug information (layer 2)
-  Serial.println("> Entering drawDebug() L2");
+  // Serial.println("> Entering drawDebug() L2");
   if (l2NeedsRedraw && debugEnabled) {
     drawText(String("Memory: ") + ESP.getFreeHeap(), 80, 10, false, WHITE, 1);
     drawText(String("Time: ") + natsumi.ageMilliseconds, 80, 20, false, WHITE, 1);
@@ -1292,7 +1286,7 @@ void drawDebug() {
 
 void drawToast() {
   // Draw toast messages (layer 3)
-  Serial.println("> Entering drawToast() L3");
+  // Serial.println("> Entering drawToast() L3");
   if (toastActive) {
     if (millis() > toastUntil) {
       // Toast expired
@@ -1319,7 +1313,7 @@ void drawToast() {
 
 void drawMenu(String menuType, const char* items[], int itemCount, int &selection) {
   // Draw menus on the screen (layer 4)
-  Serial.println("> Entering drawMenu() L4");
+  // Serial.println("> Entering drawMenu() L4");
   uint8_t key = 0;
   if (M5Cardputer.Keyboard.isChange() && M5Cardputer.Keyboard.isPressed()) {
     auto keyList = M5Cardputer.Keyboard.keyList();
@@ -2008,10 +2002,11 @@ void drawOverlay() {
   // Draw the overlay (L5)
   Serial.println("> Entering drawOverlay() L5 with l5NeedsRedraw set to " + String(l5NeedsRedraw) + " and statsActive set to " + String(statsActive));
   if (l5NeedsRedraw) {
-    Serial.println(">> l5NeedsRedraw is TRUE");
+    Serial.println(">> drawOverlay: l5NeedsRedraw is TRUE");
     uint8_t key = 0;
     if (M5Cardputer.Keyboard.isChange() && M5Cardputer.Keyboard.isPressed()) {
       auto keyList = M5Cardputer.Keyboard.keyList();
+      Serial.println(">>> drawOverlay: Testing for key pressed");
       if (keyList.size() > 0) {
         key = M5Cardputer.Keyboard.getKey(keyList[0]);
         changeState(0, HOME_LOOP, 0);
@@ -2020,6 +2015,7 @@ void drawOverlay() {
     }
     switch (currentState) {
       case HOME_LOOP:
+        Serial.println(">>> drawOverlay: HOME_LOOP");
         if (!menuOpened) {
           // Helper text at the bottom
           Serial.println("[DEBUG] manageHomeScreen() -> l5NeedsRedraw TRUE");
@@ -2028,17 +2024,19 @@ void drawOverlay() {
         }
         break;
       case STATS_SCREEN:
-        Serial.println(">> Entering drawStats()");
+        Serial.println(">>> drawOverlay: STATS_SCREEN");
         if (statsActive) {
           drawStats();
         }
         break;
       case REST_SLEEP:
+        Serial.println(">>> drawOverlay: REST_SLEEP");
         if (natsumi.energy < 4) {
           drawNapEnergyOverlay();
         }
         break;
       case REST_MEDITATE:
+        Serial.println(">>> drawOverlay: REST_MEDITATE");
         drawMeditationOverlay();
         break;
       default:

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -1255,6 +1255,7 @@ void drawCharacter() {
     l3NeedsRedraw = true;
     l4NeedsRedraw = true;
     l5NeedsRedraw = true;
+    lastMeditationDisplayed = 0;
   }
 }
 

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -616,6 +616,7 @@ void changeState(int baseLayer, GameState targetState, int delay) {
           meditationActive = true;
           meditationRewardApplied = false;
           l5NeedsRedraw = true;
+          lastMeditationDisplayed = 0;
           break;
         case REST_SLEEP:
           screenConfig = IDLE;

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -143,7 +143,7 @@ bool l5NeedsRedraw = false; // Overlay (user-defined)
 bool debugEnabled = false;
 bool menuOpened = false;
 bool toastActive = false;
-bool statsActive = false;
+bool overlayActive = false;
 
 unsigned long lastUpdate = 0;
 const int FRAME_DELAY = 50;
@@ -546,7 +546,7 @@ void changeState(int baseLayer, GameState targetState, int delay) {
           break;
         case STATS_SCREEN:
           screenConfig = GAME;
-          statsActive = true;
+          overlayActive = true;
           l5NeedsRedraw = true;
           break;
         case FOOD_MENU:
@@ -1234,7 +1234,7 @@ void meditate() {
 void drawBackground(const ImageBuffer& bg) {
   // Draw the background of the screen (layer 0)
   // Serial.println("> Entering drawBackground() L0");
-  if (l0NeedsRedraw) {
+  if (l0NeedsRedraw && !overlayActive) {
     drawImage(bg);
     l0NeedsRedraw = false;
     l1NeedsRedraw = true;
@@ -1248,7 +1248,7 @@ void drawBackground(const ImageBuffer& bg) {
 void drawCharacter() {
   // Draw the character(s) on the screen (layer 1)
   // Serial.println("> Entering drawCharacter() L1");
-  if (l1NeedsRedraw) {
+  if (l1NeedsRedraw && !overlayActive) {
     drawImage(currentCharacter);
     l1NeedsRedraw = false;
     l2NeedsRedraw = true;
@@ -2001,7 +2001,7 @@ void drawMenu(String menuType, const char* items[], int itemCount, int &selectio
 
 void drawOverlay() {
   // Draw the overlay (L5)
-  Serial.println("> Entering drawOverlay() L5 with l5NeedsRedraw set to " + String(l5NeedsRedraw) + " and statsActive set to " + String(statsActive));
+  Serial.println("> Entering drawOverlay() L5 with l5NeedsRedraw set to " + String(l5NeedsRedraw) + " and overlayActive set to " + String(overlayActive));
   if (l5NeedsRedraw) {
     Serial.println(">> drawOverlay: l5NeedsRedraw is TRUE");
     uint8_t key = 0;
@@ -2026,7 +2026,7 @@ void drawOverlay() {
         break;
       case STATS_SCREEN:
         Serial.println(">>> drawOverlay: STATS_SCREEN");
-        if (statsActive) {
+        if (overlayActive) {
           drawStats();
         }
         break;
@@ -2180,7 +2180,7 @@ void manageStats() {
     auto keyList = M5Cardputer.Keyboard.keyList();
     if (keyList.size() > 0) {
       key = M5Cardputer.Keyboard.getKey(keyList[0]);
-      statsActive = false;
+      overlayActive = false;
       changeState(0, HOME_LOOP, 0);
       return;
     }

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -749,6 +749,10 @@ void updateSpirit() {
     } else if ( spiritScore == 20 ) {
       natsumi.spirit = 4;
     }
+    Serial.println(">> updateSpirit: spiritScore=" + String(spiritScore));
+    Serial.println(">> updateSpirit: natsumi.spirit=" + String(natsumi.spirit));
+  } else {
+    Serial.println(">> updateSpirit: meditationActive is TRUE, no refresh of Spirit");
   }
   return;
 }
@@ -1181,10 +1185,12 @@ void drawMeditationOverlay() {
     M5Cardputer.Display.drawRoundRect(barX - 1, barY - 1, barW + 2, barH + 2, 7, borderColor);
   }
   if (remaining == 0) {
+    Serial.println(">> drawMeditationOverlay: End of meditation session");
     meditationActive = false;
     if (!meditationRewardApplied) {
       if (natsumi.spirit < 4 ) {
         natsumi.spirit += 1;
+        Serial.println(">> drawMeditationOverlay: natsumi.spirit=" + String(natsumi.spirit));
       }
       meditationRewardApplied = true;
     }

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -1305,6 +1305,7 @@ void drawToast() {
     M5Cardputer.Display.drawString(toastMsg, tx, ty);
     l3NeedsRedraw = false;
     l4NeedsRedraw = true;
+    l5NeedsRedraw = true;
   } else {
     l3NeedsRedraw = false;
   }


### PR DESCRIPTION
## Summary
- track meditation session timing and overlay refresh state when entering REST_MEDITATE
- render a meditation overlay with countdown, breathing guidance, and segmented progress bar
- award spirit and toast once the meditation interval completes before allowing exit

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917ee3be2548321b9aa32cba7a3bde4)