### PR TITLE
Center and zoom cook overlay icon

### DIFF
--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -3337,7 +3337,28 @@ void drawOverlay() {
         drawFoodGrid(foodGridItems, foodSelectionIndex);
         break;
       case FOOD_COOK2:
-        M5Cardputer.Display.drawPng(currentIcon.data, currentIcon.length, 111, 58);
+        {
+          const float zoom = 2.0f;
+          const int iconWidth = 18;
+          const int iconHeight = 18;
+          const int centerX = M5Cardputer.Display.width() / 2;
+          const int centerY = M5Cardputer.Display.height() / 2;
+          const int drawX = centerX - static_cast<int>((iconWidth * zoom) / 2);
+          const int drawY = centerY - static_cast<int>((iconHeight * zoom) / 2);
+
+          M5Cardputer.Display.drawPng(
+            currentIcon.data,
+            currentIcon.length,
+            drawX,
+            drawY,
+            M5Cardputer.Display.width(),
+            M5Cardputer.Display.height(),
+            0,
+            0,
+            zoom,
+            zoom
+          );
+        }
         break;
       default:
         break;


### PR DESCRIPTION
## Summary
- enlarge the cooking overlay icon when viewing FOOD_COOK2
- center the zoomed icon on the display while preserving overlay redraw behavior

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d48815a3083218137ac038402d027)