### PR TITLE
Implement TRAIN_RUN mini-game with ENTER-hold green-bar mechanic

### DIFF
--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -445,7 +445,7 @@ const int runBarHeight = 14;
 const int runBarY = 62;
 const int runGreenWidth = 44;
 const float runCursorSpeed = 0.18f;           // pixels per millisecond
-const unsigned long runTargetGreenTime = 30000;
+const unsigned long runTargetGreenTime = 10000;
 const unsigned long runMaxRedTime = 2500;
 const unsigned long runCompletionDelay = 1200;
 const unsigned long runStepInterval = 160;
@@ -2832,11 +2832,12 @@ void drawTrainRunPlayfield(bool showCompletion, bool showFailure) {
 
   M5Cardputer.Display.setTextDatum(top_left);
   M5Cardputer.Display.setTextColor(WHITE, BLACK);
-  M5Cardputer.Display.setTextSize(2);
+  M5Cardputer.Display.setTextSize(1);
   int secondsLeft = max(0, static_cast<int>((runTargetGreenTime - runGreenTime) / 1000));
-  M5Cardputer.Display.drawString(String("Hold ENTER to stay in green - ") + String(secondsLeft) + String("s"), 6, 4);
+  M5Cardputer.Display.drawString(String("Time left: ") + String(secondsLeft) + String("s"), 6, 4);
 
   if (showCompletion || showFailure) {
+    M5Cardputer.Display.fillScreen(BLACK);
     M5Cardputer.Display.setTextDatum(middle_center);
     M5Cardputer.Display.setTextSize(2);
     if (showCompletion) {

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -444,7 +444,8 @@ const int runBarWidth = 120;
 const int runBarHeight = 14;
 const int runBarY = 62;
 const int runGreenWidth = 44;
-const float runCursorSpeed = 0.18f;           // pixels per millisecond
+// const float runCursorSpeed = 0.18f;           // pixels per millisecond
+const float runCursorSpeed = 0.08f;
 const unsigned long runTargetGreenTime = 10000;
 const unsigned long runMaxRedTime = 2500;
 const unsigned long runCompletionDelay = 1200;
@@ -2814,8 +2815,6 @@ void drawTrainRunPlayfield(bool showCompletion, bool showFailure) {
   int greenStart = barX + (runBarWidth - runGreenWidth) / 2;
   int greenEnd = greenStart + runGreenWidth;
 
-  // M5Cardputer.Display.fillScreen(BLACK);
-
   int natsumiX = 6;
   int natsumiY = max(0, (screenHeight - 90) / 2);
   if (runStepIndex % 2 == 1) {
@@ -2832,9 +2831,9 @@ void drawTrainRunPlayfield(bool showCompletion, bool showFailure) {
 
   M5Cardputer.Display.setTextDatum(top_left);
   M5Cardputer.Display.setTextColor(WHITE, BLACK);
-  M5Cardputer.Display.setTextSize(1);
+  M5Cardputer.Display.setTextSize(2);
   int secondsLeft = max(0, static_cast<int>((runTargetGreenTime - runGreenTime) / 1000));
-  M5Cardputer.Display.drawString(String("Time left: ") + String(secondsLeft) + String("s"), 6, 4);
+  M5Cardputer.Display.drawString(String("Time left: ") + String(secondsLeft) + String("s "), 6, 4);
 
   if (showCompletion || showFailure) {
     M5Cardputer.Display.fillScreen(BLACK);

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -222,6 +222,12 @@ void manageTrainGymGame();
 void drawTrainGymPlayfield(bool showCompletion);
 void startTrainGymGame();
 
+// Training RUN mini-game helpers
+void resetTrainRunGame();
+void manageTrainRunGame();
+void drawTrainRunPlayfield(bool showCompletion, bool showFailure);
+void startTrainRunGame();
+
 unsigned long changeStateCounter = 0;
 
 const unsigned long hungerInterval = 120000;   // 2 minutes
@@ -432,6 +438,29 @@ unsigned long gymCompletionTime = 0;
 bool gymGameRunning = false;
 bool gymGameCompleted = false;
 bool gymNeedsRedraw = false;
+
+// Training RUN mini-game state
+const int runBarWidth = 120;
+const int runBarHeight = 14;
+const int runBarY = 62;
+const int runGreenWidth = 44;
+const float runCursorSpeed = 0.18f;           // pixels per millisecond
+const unsigned long runTargetGreenTime = 30000;
+const unsigned long runMaxRedTime = 2500;
+const unsigned long runCompletionDelay = 1200;
+const unsigned long runStepInterval = 160;
+float runCursorPos = 0.0f;
+bool runEnterHeld = false;
+unsigned long runGreenTime = 0;
+unsigned long runRedTime = 0;
+unsigned long runLastUpdate = 0;
+unsigned long runCompletionTime = 0;
+unsigned long runLastStepTime = 0;
+int runStepIndex = 0;
+bool runGameRunning = false;
+bool runGameCompleted = false;
+bool runGameFailed = false;
+bool runNeedsRedraw = false;
 
 String copyright = "(c) 2025 - Pantzumatic";
 String versionNumber = "0.6.1012";
@@ -2063,6 +2092,9 @@ void manageMiniGameCountdown() {
       case TRAIN_GYM:
         resetTrainGymGame();
         break;
+      case TRAIN_RUN:
+        resetTrainRunGame();
+        break;
       default:
         break;
     }
@@ -2088,6 +2120,9 @@ void manageMiniGameCountdown() {
         break;
       case TRAIN_GYM:
         changeState(0, TRAIN_GYM2, 0);
+        break;
+      case TRAIN_RUN:
+        changeState(0, TRAIN_RUN2, 0);
         break;
       default:
         break;
@@ -2736,8 +2771,170 @@ void manageTrainGymGame() {
   }
 }
 
+int getRunBarX() {
+  return (M5Cardputer.Display.width() - runBarWidth) / 2;
+}
+
+void resetTrainRunGame() {
+  runCursorPos = 0.0f;
+  runEnterHeld = false;
+  runGreenTime = 0;
+  runRedTime = 0;
+  runLastUpdate = 0;
+  runCompletionTime = 0;
+  runLastStepTime = 0;
+  runStepIndex = 1;
+  runGameRunning = false;
+  runGameCompleted = false;
+  runGameFailed = false;
+  runNeedsRedraw = true;
+}
+
+void startTrainRunGame() {
+  resetTrainRunGame();
+  overlayActive = false;
+  runGameRunning = true;
+  int barX = getRunBarX();
+  runCursorPos = barX + (runBarWidth / 2);
+  runLastUpdate = millis();
+  runLastStepTime = runLastUpdate;
+  M5Cardputer.Display.fillScreen(BLACK);
+}
+
+void drawTrainRunPlayfield(bool showCompletion, bool showFailure) {
+  const int screenWidth = M5Cardputer.Display.width();
+  const int screenHeight = M5Cardputer.Display.height();
+  const uint16_t barOutline = WHITE;
+  const uint16_t redZoneColor = M5Cardputer.Display.color565(220, 80, 80);
+  const uint16_t greenZoneColor = M5Cardputer.Display.color565(80, 200, 120);
+  const uint16_t cursorColor = M5Cardputer.Display.color565(255, 210, 110);
+
+  int barX = getRunBarX();
+  int barY = runBarY;
+  int greenStart = barX + (runBarWidth - runGreenWidth) / 2;
+  int greenEnd = greenStart + runGreenWidth;
+
+  M5Cardputer.Display.fillScreen(BLACK);
+
+  int natsumiX = 6;
+  int natsumiY = max(0, (screenHeight - 90) / 2);
+  if (runStepIndex % 2 == 1) {
+    M5Cardputer.Display.drawPng(natsumiSprite.data, natsumiSprite.length, natsumiX, natsumiY);
+  } else {
+    M5Cardputer.Display.drawPng(enemySprite.data, enemySprite.length, natsumiX, natsumiY);
+  }
+
+  M5Cardputer.Display.fillRect(barX, barY, runBarWidth, runBarHeight, redZoneColor);
+  M5Cardputer.Display.fillRect(greenStart, barY, runGreenWidth, runBarHeight, greenZoneColor);
+  M5Cardputer.Display.drawRect(barX - 1, barY - 1, runBarWidth + 2, runBarHeight + 2, barOutline);
+  int cursorX = static_cast<int>(runCursorPos);
+  M5Cardputer.Display.fillRect(cursorX - 2, barY - 4, 4, runBarHeight + 8, cursorColor);
+
+  M5Cardputer.Display.setTextDatum(top_left);
+  M5Cardputer.Display.setTextColor(WHITE, BLACK);
+  M5Cardputer.Display.setTextSize(1);
+  int secondsLeft = max(0, static_cast<int>((runTargetGreenTime - runGreenTime) / 1000));
+  M5Cardputer.Display.drawString(String("Hold ENTER to stay in green - ") + String(secondsLeft) + String("s"), 6, 4);
+
+  if (showCompletion || showFailure) {
+    M5Cardputer.Display.setTextDatum(middle_center);
+    M5Cardputer.Display.setTextSize(2);
+    if (showCompletion) {
+      M5Cardputer.Display.drawString("Training complete!", screenWidth / 2, screenHeight / 2);
+    } else {
+      M5Cardputer.Display.drawString("Training failed!", screenWidth / 2, screenHeight / 2);
+    }
+  }
+}
+
 void manageTrainRunGame() {
-  // MEH - Update this function
+  if (!runGameRunning && !runGameCompleted && !runGameFailed) {
+    startTrainRunGame();
+  }
+
+  unsigned long now = millis();
+
+  if (runGameCompleted || runGameFailed) {
+    if (runNeedsRedraw) {
+      drawTrainRunPlayfield(runGameCompleted, runGameFailed);
+      runNeedsRedraw = false;
+    }
+    if (now - runCompletionTime >= runCompletionDelay) {
+      changeState(0, TRAIN_RUN3, 0);
+    }
+    return;
+  }
+
+  bool enterHeld = false;
+  if (M5Cardputer.Keyboard.isPressed()) {
+    auto keyList = M5Cardputer.Keyboard.keyList();
+    for (size_t i = 0; i < keyList.size(); i++) {
+      uint8_t key = M5Cardputer.Keyboard.getKey(keyList[i]);
+      if (key == 13 || key == 40) {
+        enterHeld = true;
+        break;
+      }
+    }
+  }
+  runEnterHeld = enterHeld;
+
+  unsigned long delta = (runLastUpdate == 0) ? 0 : (now - runLastUpdate);
+  if (delta > 0 && runGameRunning) {
+    float direction = runEnterHeld ? 1.0f : -1.0f;
+    runCursorPos += runCursorSpeed * static_cast<float>(delta) * direction;
+    int barX = getRunBarX();
+    int minPos = barX;
+    int maxPos = barX + runBarWidth;
+    if (runCursorPos < minPos) {
+      runCursorPos = minPos;
+    } else if (runCursorPos > maxPos) {
+      runCursorPos = maxPos;
+    }
+
+    int greenStart = barX + (runBarWidth - runGreenWidth) / 2;
+    int greenEnd = greenStart + runGreenWidth;
+    bool inGreen = runCursorPos >= greenStart && runCursorPos <= greenEnd;
+    if (inGreen) {
+      runGreenTime += delta;
+      runRedTime = 0;
+    } else {
+      runGreenTime = 0;
+      runRedTime += delta;
+    }
+
+    if (runGreenTime >= runTargetGreenTime) {
+      runGameCompleted = true;
+      runGameRunning = false;
+      runCompletionTime = now;
+      runNeedsRedraw = true;
+      if (natsumi.fitness < 4) {
+        natsumi.fitness += 1;
+      }
+      return;
+    }
+
+    if (runRedTime >= runMaxRedTime) {
+      runGameFailed = true;
+      runGameRunning = false;
+      runCompletionTime = now;
+      runNeedsRedraw = true;
+      return;
+    }
+    runNeedsRedraw = true;
+  }
+
+  if (now - runLastStepTime >= runStepInterval) {
+    runStepIndex++;
+    runLastStepTime = now;
+    runNeedsRedraw = true;
+  }
+
+  runLastUpdate = now;
+
+  if (runNeedsRedraw) {
+    drawTrainRunPlayfield(false, false);
+    runNeedsRedraw = false;
+  }
 }
 
 void resetBathGame() {

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -2814,7 +2814,7 @@ void drawTrainRunPlayfield(bool showCompletion, bool showFailure) {
   int greenStart = barX + (runBarWidth - runGreenWidth) / 2;
   int greenEnd = greenStart + runGreenWidth;
 
-  M5Cardputer.Display.fillScreen(BLACK);
+  // M5Cardputer.Display.fillScreen(BLACK);
 
   int natsumiX = 6;
   int natsumiY = max(0, (screenHeight - 90) / 2);
@@ -2832,7 +2832,7 @@ void drawTrainRunPlayfield(bool showCompletion, bool showFailure) {
 
   M5Cardputer.Display.setTextDatum(top_left);
   M5Cardputer.Display.setTextColor(WHITE, BLACK);
-  M5Cardputer.Display.setTextSize(1);
+  M5Cardputer.Display.setTextSize(2);
   int secondsLeft = max(0, static_cast<int>((runTargetGreenTime - runGreenTime) / 1000));
   M5Cardputer.Display.drawString(String("Hold ENTER to stay in green - ") + String(secondsLeft) + String("s"), 6, 4);
 
@@ -2860,6 +2860,9 @@ void manageTrainRunGame() {
       runNeedsRedraw = false;
     }
     if (now - runCompletionTime >= runCompletionDelay) {
+      if (natsumi.fitness < 4) {
+        natsumi.fitness += 1;
+      }
       changeState(0, TRAIN_RUN3, 0);
     }
     return;
@@ -4522,6 +4525,9 @@ void drawOverlay() {
         drawDialogBubble("You missed " + String(gymMisses) + " moves. " + gymFeedback);
         break;
       }
+      case TRAIN_RUN3:
+        drawDialogBubble("Running is very good for your health, see you again very soon!!");
+        break;
       case FOOD_CONBINI2:
         drawConbimartOverlay();
         break;
@@ -5102,6 +5108,9 @@ void miniGameDebrief() {
           changeState(0, HOME_LOOP, 0);
           break;
         case TRAIN_GYM3:
+          changeState(0, HOME_LOOP, 0);
+          break;
+        case TRAIN_RUN3:
           changeState(0, HOME_LOOP, 0);
           break;
       }


### PR DESCRIPTION
### Motivation

- Add a RUN training mini-game that displays Natsumi on the left and a progress bar in the center for an interactive timing challenge.
- Provide an alternating running sprite animation using the existing preloaded images to simulate steps.
- Require the player to press and release ENTER to keep a cursor inside a green zone, while penalizing time spent in red zones.
- End the mini-game on either continuous success (30s in green) or too much time in red (failure).

### Description

- Introduced RUN game state, constants and state variables such as `runBarWidth`, `runGreenWidth`, `runCursorSpeed`, `runTargetGreenTime`, `runMaxRedTime`, `runCursorPos`, `runGreenTime`, `runRedTime`, and flags for running/completed/failed.
- Implemented `resetTrainRunGame()`, `startTrainRunGame()`, `drawTrainRunPlayfield()` and a full `manageTrainRunGame()` loop that handles ENTER input (keys `13` and `40`), cursor movement (hold ENTER moves cursor right, release moves left), green/red timing, success/failure, and transitions to `TRAIN_RUN3` on completion.
- Left-side animation toggles `runStepIndex` each step interval and displays `natsumiSprite` for odd steps or `enemySprite` for even steps to meet the requested sprite alternation.
- Hooked the RUN mini-game into the pre-game countdown by resetting the run state in `manageMiniGameCountdown()` and added helper prototypes for the new functions.

### Testing

- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b5e05933483219d3d2976289159aa)