### PR TITLE
Add flower market price selection UI and selling logic

### DIFF
--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -1904,7 +1904,7 @@ void manageCard() {
       changeState(0, FLOWERS_MARKET4, 20);
       break;
     case FLOWERS_MARKET4:
-      changeState(0, HOME_LOOP, 20);
+      changeState(0, FLOWERS_MARKET5, 20);
       break;
     case FOOD_REST6:
       changeState(0, FOOD_REST7, 20);


### PR DESCRIPTION
### Motivation
- Provide an interactive UI for selling flowers at the market with three selectable price options.
- Compute pricing based on Natsumi's combined attributes (`spirit + charm + culture`) so prices scale with her stats.
- Allow the player to choose a price with keyboard arrows and confirm or cancel the sale.

### Description
- Implemented the full `manageFlowersMarket()` routine to compute `handicapScore` and populate three price tiers based on the score ranges.
- Added keyboard handling for LEFT/RIGHT to move selection, `ESC` to exit to `HOME_LOOP` (via `changeState(0, HOME_LOOP, 0)`), and ENTER to sell all `natsumi.flowers` at the selected price and add to `natsumi.money`.
- Render three rounded buttons showing the computed prices, with visual highlight for the currently selected button and helper text drawn via `drawText`.
- Use local initialization flags (`flowerMarketInitialized`, `flowerMarketNeedsRedraw`) and clear `overlayActive` / reset state after selling or cancelling.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69508de75be883219c4828501d4c456c)