### PR TITLE
Display flowers at 2× size in manageFlowersSale

### DIFF
--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -3818,8 +3818,9 @@ void manageFlowersSale() {
   static std::vector<std::pair<int, int>> flowerPositions;
   static bool flowerSaleNeedsRedraw = true;
 
-  const int spriteW = 10;
-  const int spriteH = 16;
+  const int spriteScale = 2;
+  const int spriteW = 10 * spriteScale;
+  const int spriteH = 16 * spriteScale;
   const int padding = 4;
   const int initialX = 60;
   const int initialY = 30;
@@ -3876,7 +3877,12 @@ void manageFlowersSale() {
           natsumiSprite.data,
           natsumiSprite.length,
           position.first,
-          position.second
+          position.second,
+          0,
+          0,
+          0,
+          0,
+          spriteScale
         );
       }
     }

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -3822,8 +3822,8 @@ void manageFlowersSale() {
   const int spriteW = 10 * spriteScale;
   const int spriteH = 16 * spriteScale;
   const int padding = 4;
-  const int initialX = 60;
-  const int initialY = 30;
+  const int initialX = 20;
+  const int initialY = 10;
   const int screenWidth = M5Cardputer.Display.width();
   const int screenHeight = M5Cardputer.Display.height();
 
@@ -3833,7 +3833,8 @@ void manageFlowersSale() {
     flowerSlots.clear();
     flowerPositions.clear();
 
-    int columns = (screenWidth - padding) / (spriteW + padding);
+    // int columns = (screenWidth - padding) / (spriteW + padding);
+    int columns = 8;
     if (columns < 1) {
       columns = 1;
     }
@@ -3843,6 +3844,8 @@ void manageFlowersSale() {
       int row = i / columns;
       int x = initialX + padding + col * (spriteW + padding);
       int y = initialY + padding + row * (spriteH + padding);
+      // int x = padding + col * (spriteW + padding);
+      // int y = padding + row * (spriteH + padding);
       flowerPositions.push_back({x, y});
       flowerSlots.push_back(i);
     }


### PR DESCRIPTION
### Motivation
- The flower sprites shown during a sale should be rendered at double size to improve visibility and match updated assets.
- Layout calculations need to reflect the larger sprite dimensions so flowers are positioned without overlap.

### Description
- Introduced a `spriteScale` (set to `2`) and updated `spriteW` and `spriteH` to be multiplied by that scale in `manageFlowersSale`.
- Updated grid/position math so column/row and `flowerPositions` use the scaled `spriteW`/`spriteH` values.
- Modified the `M5Cardputer.Display.drawPng` call to pass the scale parameter so sprites are rendered at 2× size.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951150550d8832195ef1200000605b9)