### PR TITLE
Add falling-notes competition minigame and new COMP_*5 states

### DIFF
--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -4678,12 +4678,20 @@ void drawMenu(String menuType, const char* items[], int itemCount, int &selectio
         case 49:
           // 1: RESTAURANT
           menuOpened = false;
-          changeState(0, FOOD_REST, 0);
+          if (natsumi.age > 15) {
+            changeState(0, FOOD_REST, 0);
+          } else {
+            showToast("Too young to go there");
+          }
           break;
         case 50:
           // 2: ORDER
           menuOpened = false;
-          changeState(0, FOOD_ORDER, 0);
+          if (natsumi.age > 13) {
+            changeState(0, FOOD_ORDER, 0);
+          } else {
+            showToast("Too young to use this");
+          }
           break;
         case 51:
           // 3: CONBINI
@@ -4853,22 +4861,60 @@ void drawMenu(String menuType, const char* items[], int itemCount, int &selectio
         case 48:
           // 0: LOCAL
           menuOpened = false;
-          changeState(0, COMP_LOCAL, 0);
+          if (natsumi.age > 13) {
+            if (natsumi.competition == 0) {
+              changeState(0, COMP_LOCAL, 0);
+            } else {
+              showToast("Already completed");
+            }
+          } else {
+            showToast("Too young to compete");
+          }
           break;
         case 49:
           // 1: DEPARTMENTAL
           menuOpened = false;
-          changeState(0, COMP_DEPT5, 0);
+          if (natsumi.age > 15) {
+            if (natsumi.competition == 1) {
+              changeState(0, COMP_DEPT5, 0);
+            } else if (natsumi.competition < 1) {
+              showToast("Complete local comp. 1st");
+            } else {
+              showToast("Already completed");
+            }
+          } else {
+            showToast("Too young to compete");
+          }
           break;
         case 50:
           // 2: REGIONAL
           menuOpened = false;
-          changeState(0, COMP_REG5, 0);
+          if (natsumi.age > 15) {
+            if (natsumi.competition == 2) {
+              changeState(0, COMP_REG5, 0);
+            } else if (natsumi.competition < 2) {
+              showToast("Complete lower comp. 1st");
+            } else {
+              showToast("Already completed");
+            }
+          } else {
+            showToast("Too young to compete");
+          }
           break;
         case 51:
           // 3: NATIONAL
           menuOpened = false;
-          changeState(0, COMP_NAT5, 0);
+          if (natsumi.age > 15) {
+            if (natsumi.competition == 3) {
+              changeState(0, COMP_NAT5, 0);
+            } else if (natsumi.competition < 3) {
+              showToast("Complete lower comp. 1st");
+            } else {
+              showToast("Already completed");
+            }
+          } else {
+            showToast("Too young to compete");
+          }
           break;
         case 55:
           // 7: DEBUG

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -137,6 +137,7 @@ struct NatsumiStats {
   int charm;
   int money;
   int flowers;
+  int competition;
   unsigned long lastHungerUpdate = 0;
   unsigned long lastHygieneUpdate = 0;
   unsigned long lastEnergyUpdate = 0;
@@ -1456,6 +1457,7 @@ void changeState(int baseLayer, GameState targetState, int delay) {
         natsumi.charm = 0;
         natsumi.money = 1800;
         natsumi.flowers = 0;
+        natsumi.competition = 0;
         natsumi.lastHungerUpdate = 0;
         natsumi.lastHygieneUpdate = 0;
         natsumi.lastEnergyUpdate = 0;
@@ -1503,6 +1505,7 @@ void changeState(int baseLayer, GameState targetState, int delay) {
         natsumi.charm = 0;
         natsumi.money = 1800;
         natsumi.flowers = 0;
+        natsumi.competition = 0;
         natsumi.lastHungerUpdate = 0;
         natsumi.lastHygieneUpdate = 0;
         natsumi.lastEnergyUpdate = 0;
@@ -4167,6 +4170,7 @@ void manageCompetition() {
   unsigned long now = millis();
 
   if (competitionCompleted) {
+    /*
     if (competitionCompletionTime == 0) {
       competitionCompletionTime = now;
     }
@@ -4174,7 +4178,39 @@ void manageCompetition() {
       competitionInitialized = false;
       changeState(0, COMP_LOCAL6, microWait);
     }
-    return;
+    */
+    if (competitionNotesCollected == targetNotes) {
+      switch (currentState) {
+        case COMP_LOCAL5:
+          if (natsumi.competition == 0) {
+            natsumi.competition = 1;
+            showToast("Departmental competition unlocked");
+          }
+          break;
+        case COMP_DEPT5:
+          if (natsumi.competition == 1) {
+            natsumi.competition = 2;
+            showToast("Regional competition unlocked");
+          }
+          break;
+        case COMP_REG5:
+          if (natsumi.competition == 2) {
+            natsumi.competition = 3;
+            showToast("National competition unlocked");
+          }
+          break;
+        case COMP_NAT5:
+          if (natsumi.competition == 3) {
+            natsumi.competition = 4;
+          }
+          break;
+      }
+      competitionInitialized = false;
+      changeState(0, COMP_LOCAL6, 0);
+      return;
+    }
+  } else {
+    showToast("Train more to unlock next level");
   }
 
   if (M5Cardputer.Keyboard.isChange() && M5Cardputer.Keyboard.isPressed()) {
@@ -4185,11 +4221,15 @@ void manageCompetition() {
         case 180: case 44: case 'a': case 'A':  // LEFT
           if (competitionPlayerColumn > 0) {
             competitionPlayerColumn--;
+          } else if (competitionPlayerColumn == 0) {
+            competitionPlayerColumn = competitionColumns - 1;
           }
           break;
         case 183: case 47: case 'd': case 'D':  // RIGHT
           if (competitionPlayerColumn < competitionColumns - 1) {
             competitionPlayerColumn++;
+          } else if (competitionPlayerColumn == competitionColumns - 1) {
+            competitionPlayerColumn = 0;
           }
           break;
         default:
@@ -4227,7 +4267,8 @@ void manageCompetition() {
     competitionCompleted = true;
   }
 
-  drawImage(currentBackground);
+  // drawImage(currentBackground);
+  M5Cardputer.Display.fillRect(0, 0, 240, 135, BLACK);
 
   for (int i = 1; i < competitionColumns; i++) {
     int x = i * competitionColumnWidth;

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -4115,7 +4115,7 @@ void manageCompetition() {
   static unsigned long competitionCompletionTime = 0;
   static bool competitionCompleted = false;
 
-  const int targetNotes = 10;
+  const int targetNotes = 50;
   const int noteRadius = 5;
   const int playerWidth = 22;
   const int playerHeight = 20;
@@ -4138,18 +4138,23 @@ void manageCompetition() {
 
     switch (currentState) {
       case COMP_LOCAL5:
+        Serial.println(">> COMP_LOCAL5 - 3 columns");
         competitionColumns = 3;
         break;
       case COMP_DEPT5:
+        Serial.println(">> COMP_DEPT5 - 4 columns");
         competitionColumns = 4;
         break;
       case COMP_REG5:
+        Serial.println(">> COMP_REG5 - 5 columns");
         competitionColumns = 5;
         break;
       case COMP_NAT5:
+        Serial.println(">> COMP_NAT5 - 6 columns");
         competitionColumns = 6;
         break;
       default:
+        Serial.println(">> default - 3 columns");
         competitionColumns = 3;
         break;
     }

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -4681,6 +4681,7 @@ void drawMenu(String menuType, const char* items[], int itemCount, int &selectio
           if (natsumi.age > 15) {
             changeState(0, FOOD_REST, 0);
           } else {
+            changeState(0, HOME_LOOP, 0);
             showToast("Too young to go there");
           }
           break;
@@ -4690,6 +4691,7 @@ void drawMenu(String menuType, const char* items[], int itemCount, int &selectio
           if (natsumi.age > 13) {
             changeState(0, FOOD_ORDER, 0);
           } else {
+            changeState(0, HOME_LOOP, 0);
             showToast("Too young to use this");
           }
           break;
@@ -4732,9 +4734,19 @@ void drawMenu(String menuType, const char* items[], int itemCount, int &selectio
           if (selection == 0) {
             changeState(0, FOOD_COOK, 0);
           } else if (selection == 1) {
-            changeState(0, FOOD_REST, 0);
+            if (natsumi.age > 15) {
+              changeState(0, FOOD_REST, 0);
+            } else {
+              changeState(0, HOME_LOOP, 0);
+              showToast("Too young to go there");
+            }
           } else if (selection == 2) {
-            changeState(0, FOOD_ORDER, 0);
+            if (natsumi.age > 13) {
+              changeState(0, FOOD_ORDER, 0);
+            } else {
+              changeState(0, HOME_LOOP, 0);
+              showToast("Too young to use this");
+            }
           } else if (selection == 3) {
             changeState(0, FOOD_CONBINI, 0);
           } else if (selection == 4) {
@@ -4860,14 +4872,17 @@ void drawMenu(String menuType, const char* items[], int itemCount, int &selectio
       switch (key) {
         case 48:
           // 0: LOCAL
+          Serial.println(">> Local competition, age = " + String(natsumi.age));
           menuOpened = false;
           if (natsumi.age > 13) {
             if (natsumi.competition == 0) {
               changeState(0, COMP_LOCAL, 0);
             } else {
+              changeState(0, HOME_LOOP, 0);
               showToast("Already completed");
             }
           } else {
+            changeState(0, HOME_LOOP, 0);
             showToast("Too young to compete");
           }
           break;
@@ -4878,11 +4893,14 @@ void drawMenu(String menuType, const char* items[], int itemCount, int &selectio
             if (natsumi.competition == 1) {
               changeState(0, COMP_DEPT5, 0);
             } else if (natsumi.competition < 1) {
+              changeState(0, HOME_LOOP, 0);
               showToast("Complete local comp. 1st");
             } else {
+              changeState(0, HOME_LOOP, 0);
               showToast("Already completed");
             }
           } else {
+            changeState(0, HOME_LOOP, 0);
             showToast("Too young to compete");
           }
           break;
@@ -4893,11 +4911,14 @@ void drawMenu(String menuType, const char* items[], int itemCount, int &selectio
             if (natsumi.competition == 2) {
               changeState(0, COMP_REG5, 0);
             } else if (natsumi.competition < 2) {
+              changeState(0, HOME_LOOP, 0);
               showToast("Complete lower comp. 1st");
             } else {
+              changeState(0, HOME_LOOP, 0);
               showToast("Already completed");
             }
           } else {
+            changeState(0, HOME_LOOP, 0);
             showToast("Too young to compete");
           }
           break;
@@ -4908,11 +4929,14 @@ void drawMenu(String menuType, const char* items[], int itemCount, int &selectio
             if (natsumi.competition == 3) {
               changeState(0, COMP_NAT5, 0);
             } else if (natsumi.competition < 3) {
+              changeState(0, HOME_LOOP, 0);
               showToast("Complete lower comp. 1st");
             } else {
+              changeState(0, HOME_LOOP, 0);
               showToast("Already completed");
             }
           } else {
+            changeState(0, HOME_LOOP, 0);
             showToast("Too young to compete");
           }
           break;
@@ -4959,13 +4983,60 @@ void drawMenu(String menuType, const char* items[], int itemCount, int &selectio
         case 13: case 40: case ' ':
           // VALIDATE
           if (selection == 0) {
-            changeState(0, COMP_LOCAL, 0);
+            if (natsumi.age > 13) {
+              if (natsumi.competition == 0) {
+                changeState(0, COMP_LOCAL, 0);
+              } else {
+                showToast("Already completed");
+              }
+            } else {
+              showToast("Too young to compete");
+            }
           } else if (selection == 1) {
-            changeState(0, COMP_DEPT5, 0);
+            if (natsumi.age > 15) {
+              if (natsumi.competition == 1) {
+                changeState(0, COMP_DEPT5, 0);
+              } else if (natsumi.competition < 1) {
+                changeState(0, HOME_LOOP, 0);
+                showToast("Complete local comp. 1st");
+              } else {
+                changeState(0, HOME_LOOP, 0);
+                showToast("Already completed");
+              }
+            } else {
+              changeState(0, HOME_LOOP, 0);
+              showToast("Too young to compete");
+            }
           } else if (selection == 2) {
-            changeState(0, COMP_REG5, 0);
+            if (natsumi.age > 15) {
+              if (natsumi.competition == 2) {
+                changeState(0, COMP_REG5, 0);
+              } else if (natsumi.competition < 2) {
+                changeState(0, HOME_LOOP, 0);
+                showToast("Complete lower comp. 1st");
+              } else {
+                changeState(0, HOME_LOOP, 0);
+                showToast("Already completed");
+              }
+            } else {
+              changeState(0, HOME_LOOP, 0);
+              showToast("Too young to compete");
+            }
           } else if (selection == 3) {
-            changeState(0, COMP_NAT5, 0);
+            if (natsumi.age > 15) {
+              if (natsumi.competition == 3) {
+                changeState(0, COMP_NAT5, 0);
+              } else if (natsumi.competition < 3) {
+                changeState(0, HOME_LOOP, 0);
+                showToast("Complete lower comp. 1st");
+              } else {
+                changeState(0, HOME_LOOP, 0);
+                showToast("Already completed");
+              }
+            } else {
+              changeState(0, HOME_LOOP, 0);
+              showToast("Too young to compete");
+            }
           } else if (selection == 7) {
             if (debugActive) {
               debugActive = false;


### PR DESCRIPTION
### Motivation
- Provide playable competition mini-games for higher tiers (departmental, regional, national) with interactive falling-note mechanics.
- Make the number of columns vary by competition tier so difficulty scales with state (`COMP_LOCAL5`=3, `COMP_DEPT5`=4, `COMP_REG5`=5, `COMP_NAT5`=6).
- Let the player move `Natsumi` horizontally with arrow keys to collect music notes and finish the game after collecting 10 notes.
- Integrate the new competition states into state transitions and asset preloading so the UI and flow behave correctly.

### Description
- Added new `GameState` values: `COMP_DEPT5`, `COMP_REG5`, and `COMP_NAT5`, and updated `gameStateToString` mappings.
- Routed competition menu selections to the new states and updated `preloadImages` and `changeState` so those states use the competition background and are treated as `GAME` screens.
- Implemented `manageCompetition()` to run a falling-notes minigame that spawns notes in random columns, moves them downward, accepts LEFT/RIGHT keyboard input to move `Natsumi`, detects collection when notes reach the player lane, and completes when `10` notes are collected.
- Wired the new states into `manageGame()` and ensured the playfield draws lanes, notes, and the `natsumiSprite` player; completed games transition to the debrief state `COMP_LOCAL6`.

### Testing
- No automated unit or integration tests were executed on the modified code.
- The changes were added and committed as `Implement competition falling notes game` but no build/run verification was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695332828c948321bfd1a6d823a190c9)