### PR TITLE
Add title screen music playback and stop on state change

### DIFF
--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -127,6 +127,8 @@ GameState priestState = HOME_LOOP;
 GameState loadedContinueState = HOME_LOOP;
 bool continueStateLoaded = false;
 
+const char* titleScreenMusicPath = "/idolnat/music/Minami Toshida - Night Train to Osaka (1988).wav";
+
 // === Screen configs definitions ===
 enum ScreenState {
   CARD,
@@ -1642,10 +1644,29 @@ void drawImage(const ImageBuffer& img) {
   }
 }
 
+void updateTitleScreenMusic() {
+  static bool titleMusicPlaying = false;
+  if (currentState == TITLE_SCREEN2) {
+    if (!titleMusicPlaying) {
+      M5Cardputer.Speaker.playWav(titleScreenMusicPath);
+      titleMusicPlaying = true;
+    }
+    return;
+  }
+
+  if (currentState == NEW_GAME || currentState == CONTINUE_GAME) {
+    if (titleMusicPlaying) {
+      M5Cardputer.Speaker.stop();
+      titleMusicPlaying = false;
+    }
+  }
+}
+
 // === Setup and loop ===
 void setup() {
   auto cfg = M5.config();
   M5Cardputer.begin(cfg);
+  M5Cardputer.Speaker.begin();
   delay(1000);
   Serial.begin(115200);
   delay(1000);
@@ -1665,6 +1686,7 @@ void loop() {
   if (millis() - lastUpdate < FRAME_DELAY) return;
   lastUpdate = millis();
   updateFiveSecondPulse();
+  updateTitleScreenMusic();
 /*
   Serial.println("l0NeedsRedraw: " + String(l0NeedsRedraw) + " - l1NeedsRedraw: " + String(l1NeedsRedraw) + " - l2NeedsRedraw: " + String(l2NeedsRedraw) + " - l3NeedsRedraw: " + String(l3NeedsRedraw));
   Serial.println("l4NeedsRedraw: " + String(l4NeedsRedraw) + " - l5NeedsRedraw: " + String(l5NeedsRedraw));

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -1648,7 +1648,7 @@ void updateTitleScreenMusic() {
   static bool titleMusicPlaying = false;
   if (currentState == TITLE_SCREEN2) {
     if (!titleMusicPlaying) {
-      M5Cardputer.Speaker.playWav(titleScreenMusicPath);
+      M5Cardputer.Speaker.playWav(SD, titleScreenMusicPath);
       titleMusicPlaying = true;
     }
     return;


### PR DESCRIPTION
### Motivation
- Play a WAV file while the game is showing the title menu state and stop it when starting or continuing a game.
- Ensure the speaker is initialized so playback calls succeed.
- Keep state-driven audio control localized and updated each main loop tick.

### Description
- Added `titleScreenMusicPath` pointing to `/idolnat/music/Minami Toshida - Night Train to Osaka (1988).wav`.
- Implemented `updateTitleScreenMusic()` which calls `M5Cardputer.Speaker.playWav()` when `currentState` is `TITLE_SCREEN2` and calls `M5Cardputer.Speaker.stop()` when transitioning to `NEW_GAME` or `CONTINUE_GAME`.
- Initialized the speaker with `M5Cardputer.Speaker.begin()` in `setup()` and invoked `updateTitleScreenMusic()` from `loop()` each tick.

### Testing
- No automated tests were run against these changes.
- Manual runtime testing was not recorded in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695497e3b9e483219066ea969cadf135)