### PR TITLE
Fix aging playtime accumulation

### DIFF
--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -711,6 +711,7 @@ bool saveGameToSd() {
   unsigned long currentPlaytime = currentMilli - sessionStart;
   unsigned long totalMs = playtimeTotalMs + currentPlaytime;
   playtimeTotalMs = totalMs;
+  sessionStart = currentMilli;
 
   saveFile.println("[version]");
   saveFile.println(String(versionNumber));
@@ -913,6 +914,7 @@ bool loadGameFromSd() {
   }
 
   saveFile.close();
+  sessionStart = millis();
   Serial.println(">> loadGameFromSd: Load complete");
   Serial.println(">>> loadGameFromSd - natsumi.ageMilliseconds: " + String(natsumi.ageMilliseconds));
   Serial.println(">>> loadGameFromSd - playtimeTotalMs: " + String(playtimeTotalMs));


### PR DESCRIPTION
### Motivation
- The game was aging the character too quickly because accumulated playtime could be double-counted across save/load boundaries, inflating `playtimeTotalMs` and causing `updateAging()` to advance age faster than the intended 24-hour interval. 

### Description
- After computing and storing the updated playtime in `saveGameToSd()` the code now resets `sessionStart` to the current timestamp (`sessionStart = currentMilli`) to avoid re-counting elapsed time. 
- After loading a save in `loadGameFromSd()` the code now resets `sessionStart` to the current `millis()` (`sessionStart = millis()`) so subsequent playtime deltas start from the load moment. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696737149ac08321a4839d7db877c1a4)