### PR TITLE
Harden save writes with temp file + backup recovery

### DIFF
--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -324,6 +324,8 @@ const unsigned long shortWait = 200;
 const unsigned long mediumWait = 3200;
 const unsigned long longWait = 6400;
 const char* saveGamePath = "/idolnat/savegame.dat";
+const char* saveGameTempPath = "/idolnat/savegame.tmp";
+const char* saveGameBackupPath = "/idolnat/savegame.bak";
 String saveStatusMsg = "";
 unsigned long saveStatusUntil = 0;
 unsigned long counterToScreensaver = 0;
@@ -863,11 +865,11 @@ bool isCompetitionEnabled() {
 
 bool saveGameToSd() {
   Serial.println(">> saveGameToSd: Writing save data");
-  if (SD.exists(saveGamePath)) {
-    SD.remove(saveGamePath);
+  if (SD.exists(saveGameTempPath)) {
+    SD.remove(saveGameTempPath);
   }
 
-  File saveFile = SD.open(saveGamePath, FILE_WRITE);
+  File saveFile = SD.open(saveGameTempPath, FILE_WRITE);
   if (!saveFile) {
     Serial.println(">> saveGameToSd: Failed to open save file");
     return false;
@@ -986,6 +988,25 @@ bool saveGameToSd() {
   saveFile.println("bday_visit_enabled=" + String(birthdayVisitEnabled));
 
   saveFile.close();
+
+  if (SD.exists(saveGameBackupPath)) {
+    SD.remove(saveGameBackupPath);
+  }
+  if (SD.exists(saveGamePath) && !SD.rename(saveGamePath, saveGameBackupPath)) {
+    Serial.println(">> saveGameToSd: Failed to rotate existing save to backup");
+    SD.remove(saveGameTempPath);
+    return false;
+  }
+
+  if (!SD.rename(saveGameTempPath, saveGamePath)) {
+    Serial.println(">> saveGameToSd: Failed to promote temporary save");
+    if (SD.exists(saveGameBackupPath)) {
+      SD.rename(saveGameBackupPath, saveGamePath);
+    }
+    SD.remove(saveGameTempPath);
+    return false;
+  }
+
   Serial.println(">> saveGameToSd: Save complete");
   return true;
 }
@@ -993,13 +1014,26 @@ bool saveGameToSd() {
 bool loadGameFromSd() {
   Serial.println(">> loadGameFromSd: Loading save data");
   loadedContinueState = HOME_LOOP;
-  if (!SD.exists(saveGamePath)) {
-    Serial.println(">> loadGameFromSd: Save file not found");
-    showToast("Save file not found");
-    return false;
+
+  const char* loadPath = saveGamePath;
+  if (!SD.exists(loadPath)) {
+    if (SD.exists(saveGameBackupPath)) {
+      Serial.println(">> loadGameFromSd: Primary save missing, trying backup");
+      loadPath = saveGameBackupPath;
+    } else {
+      Serial.println(">> loadGameFromSd: Save file not found");
+      showToast("Save file not found");
+      return false;
+    }
   }
 
-  File saveFile = SD.open(saveGamePath, FILE_READ);
+  File saveFile = SD.open(loadPath, FILE_READ);
+  if (!saveFile && loadPath == saveGamePath && SD.exists(saveGameBackupPath)) {
+    Serial.println(">> loadGameFromSd: Failed to open primary save, trying backup");
+    loadPath = saveGameBackupPath;
+    saveFile = SD.open(loadPath, FILE_READ);
+  }
+
   if (!saveFile) {
     Serial.println(">> loadGameFromSd: Failed to open save file");
     showToast("Corrupted save file");
@@ -1152,7 +1186,11 @@ bool loadGameFromSd() {
   Serial.println(">> loadGameFromSd: Load complete");
   Serial.println(">>> loadGameFromSd - natsumi.ageMilliseconds: " + String(natsumi.ageMilliseconds));
   Serial.println(">>> loadGameFromSd - playtimeTotalMs: " + String(playtimeTotalMs));
-  showToast("Save file loaded");
+  if (loadPath == saveGameBackupPath) {
+    showToast("Backup save loaded");
+  } else {
+    showToast("Save file loaded");
+  }
   return true;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent save corruption when power is lost during a write by avoiding destructive in-place writes to `/idolnat/savegame.dat`.
- Keep a recoverable copy of the last-good save so the game can fall back automatically if the latest write is incomplete.

### Description
- Add `saveGameTempPath` and `saveGameBackupPath` and change save flow to write to `savegame.tmp` then atomically promote it to `savegame.dat` via `SD.rename` to avoid leaving an empty/partial primary save.
- Rotate the existing `savegame.dat` to `savegame.bak` before promoting the temp file and restore the backup if promotion fails to provide rollback semantics.
- Update the load logic to try the primary save first and automatically fall back to `savegame.bak` if the primary is missing or cannot be opened, and show a distinct toast when the backup was used.

### Testing
- Ran `git diff --check` to validate there are no whitespace/git-diff issues and it passed. 
- Attempted environment compile/upload checks but `arduino-cli` is not available in this environment so firmware build/flash validation was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e52f0fec83218503977a42c78dce)