### PR TITLE
Add hit/miss full-screen flash feedback in sing training mini-game

### DIFF
--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -525,6 +525,7 @@ const int singPlayerWidth = 22;
 const int singPlayerHeight = 10;
 const unsigned long singNoteSpawnInterval = 700;
 const int singNoteFallSpeed = 3;
+const unsigned long singFlashDuration = 70;
 int singColumnWidth = 48;
 int singPlayerY = 118;
 int singPlayerColumn = singColumnCount / 2;
@@ -532,6 +533,8 @@ int singNotesCollected = 0;
 int singNotesSpawned = 0;
 unsigned long singLastSpawnTime = 0;
 unsigned long singCompletionTime = 0;
+unsigned long singFlashUntil = 0;
+uint16_t singFlashColor = BLACK;
 bool singGameRunning = false;
 bool singGameCompleted = false;
 std::vector<FallingNote> singNotes;
@@ -4868,6 +4871,8 @@ void resetTrainSingGame() {
   singPlayerColumn = singColumnCount / 2;
   singLastSpawnTime = 0;
   singCompletionTime = 0;
+  singFlashUntil = 0;
+  singFlashColor = BLACK;
   singGameRunning = false;
   singGameCompleted = false;
 }
@@ -4975,8 +4980,12 @@ void manageTrainSingGame() {
       if (note.column == singPlayerColumn) {
         singNotesCollected++;
         note.active = false;
-      } else if (note.y > M5Cardputer.Display.height()) {
+        singFlashColor = M5Cardputer.Display.color565(40, 220, 80);
+        singFlashUntil = now + singFlashDuration;
+      } else {
         note.active = false;
+        singFlashColor = M5Cardputer.Display.color565(220, 40, 40);
+        singFlashUntil = now + singFlashDuration;
       }
     }
   }
@@ -4992,6 +5001,11 @@ void manageTrainSingGame() {
       natsumi.performance += 1;
     }
     drawTrainSingPlayfield(true);
+    return;
+  }
+
+  if (now < singFlashUntil) {
+    M5Cardputer.Display.fillScreen(singFlashColor);
     return;
   }
 

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -530,6 +530,7 @@ int singColumnWidth = 48;
 int singPlayerY = 118;
 int singPlayerColumn = singColumnCount / 2;
 int singNotesCollected = 0;
+int singNotesMissed = 0;
 int singNotesSpawned = 0;
 unsigned long singLastSpawnTime = 0;
 unsigned long singCompletionTime = 0;
@@ -4867,6 +4868,7 @@ void drawTrainDancePlayfield() {
 void resetTrainSingGame() {
   singNotes.clear();
   singNotesCollected = 0;
+  singNotesMissed = 0;
   singNotesSpawned = 0;
   singPlayerColumn = singColumnCount / 2;
   singLastSpawnTime = 0;
@@ -4983,6 +4985,7 @@ void manageTrainSingGame() {
         singFlashColor = M5Cardputer.Display.color565(40, 220, 80);
         singFlashUntil = now + singFlashDuration;
       } else {
+        singNotesMissed++;
         note.active = false;
         singFlashColor = M5Cardputer.Display.color565(220, 40, 40);
         singFlashUntil = now + singFlashDuration;
@@ -4997,8 +5000,10 @@ void manageTrainSingGame() {
   if (singNotesCollected >= singTargetNotes) {
     singGameCompleted = true;
     singCompletionTime = now;
-    if (natsumi.performance < 4) {
-      natsumi.performance += 1;
+    if (singNotesMissed == 0) {
+      if (natsumi.performance < 4) {
+        natsumi.performance += 1;
+      }
     }
     drawTrainSingPlayfield(true);
     return;
@@ -7980,10 +7985,10 @@ void drawOverlay() {
         break;
       }
       case TRAIN_SING3: {
-        int missedMusicCoins = singNotesSpawned - singNotesCollected;
+        // int missedMusicCoins = singNotesSpawned - singNotesCollected;
         String musicTeacherFeedback = "";
         isLatestTrainingPerfect = false;
-        switch(missedMusicCoins) {
+        switch(singNotesMissed) {
           case 0:
             musicTeacherFeedback = "excellent!!";
             isLatestTrainingPerfect = true;
@@ -8001,7 +8006,7 @@ void drawOverlay() {
             musicTeacherFeedback = "very bad...";
             break;
         }
-        drawDialogBubble("You collected " + String(singNotesCollected) + " / " + String(singNotesSpawned) +" music coins (missed " + String(missedMusicCoins) +"). Your performance was " + musicTeacherFeedback);
+        drawDialogBubble("You collected " + String(singNotesCollected) + " / " + String(singNotesSpawned) +" music coins (missed " + String(singNotesMissed) +"). Your performance was " + musicTeacherFeedback);
         break;
       }
       case TRAIN_SWIM3: {

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -5011,6 +5011,7 @@ void manageTrainSingGame() {
 
   if (now < singFlashUntil) {
     M5Cardputer.Display.fillScreen(singFlashColor);
+    // M5Cardputer.Display.fillRect(0, 130, 240, 5, singFlashColor);
     return;
   }
 
@@ -8006,7 +8007,7 @@ void drawOverlay() {
             musicTeacherFeedback = "very bad...";
             break;
         }
-        drawDialogBubble("You collected " + String(singNotesCollected) + " / " + String(singNotesSpawned) +" music coins (missed " + String(singNotesMissed) +"). Your performance was " + musicTeacherFeedback);
+        drawDialogBubble("You missed " + String(singNotesMissed) +" notes. Your performance was " + musicTeacherFeedback);
         break;
       }
       case TRAIN_SWIM3: {


### PR DESCRIPTION
### Motivation
- Provide immediate, high-contrast visual feedback when a singing note is caught or missed so players can more clearly perceive hits and misses during the training SING mini-game.
- Keep the feedback brief and non-disruptive so gameplay flow is preserved.

### Description
- Added `singFlashDuration`, `singFlashUntil`, and `singFlashColor` state variables to the SING game to track a short-lived full-screen flash. 
- Reset the flash state in `resetTrainSingGame()` by clearing `singFlashUntil` and setting `singFlashColor` to `BLACK` so each run starts clean.
- Updated `manageTrainSingGame()` to set `singFlashColor` to a green color and `singFlashUntil` on successful note captures, and to a red color and `singFlashUntil` on misses.
- During an active flash window (`now < singFlashUntil`) the routine now calls `M5Cardputer.Display.fillScreen(singFlashColor)` and returns early, rendering the flash for the configured duration before resuming normal playfield drawing.

### Testing
- Ran repository checks: `git diff` on the modified file and `git status --short`, and the `git` commit; these operations completed successfully. 
- No firmware build or device run was executed in this environment, so the change was not compiled or visually validated on hardware.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc9d3474088321b57bc9ad0b570000)