### PR TITLE
Add key-release guard to miniGameDebrief to prevent accidental skip

### DIFF
--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -9547,6 +9547,21 @@ void foodDelivery() {
 
 void miniGameDebrief() {
   Serial.println("> Entering miniGameDebrief()");
+  static GameState debriefState = VERSION_SCREEN;
+  static bool waitKeyRelease = false;
+
+  if (debriefState != currentState) {
+    debriefState = currentState;
+    waitKeyRelease = true;
+  }
+
+  if (waitKeyRelease) {
+    if (!M5Cardputer.Keyboard.isPressed()) {
+      waitKeyRelease = false;
+    }
+    return;
+  }
+
   uint8_t key = 0;
   if (M5Cardputer.Keyboard.isChange() && M5Cardputer.Keyboard.isPressed()) {
     auto keyList = M5Cardputer.Keyboard.keyList();


### PR DESCRIPTION
### Motivation
- The final keypress at the end of competition gameplay (`COMP_*5`) was being carried into the debrief state (`COMP_*6`), causing the `drawDialogBubble` debrief to be skipped when the key registered as an immediate confirmation.

### Description
- Added a small state-aware key-release gate to `miniGameDebrief()` by tracking `debriefState` and a `waitKeyRelease` flag, setting `waitKeyRelease` when `currentState` changes, and returning early until no key is pressed so normal confirm handling resumes only after release.

### Testing
- Applied the patch and committed the change to `idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino`, and the commit operation completed successfully.
- No automated unit tests were executed for this change in the current workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5ca849fe48321b0047c3aecb6e214)