### PR TITLE
Center character PNG in PFC_GAME9 overlay

### DIFF
--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -8711,8 +8711,6 @@ void drawOverlay() {
         // Helper text
         drawHelper(pfcHelperText);
         break;
-      default:
-        break;
     }
   }
   l5NeedsRedraw = false;

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -8697,8 +8697,16 @@ void drawOverlay() {
         // Bg
         M5Cardputer.Display.drawPng(currentBackground.data, currentBackground.length, 0, 0);
 
-        // Character
-        M5Cardputer.Display.drawPng(currentCharacter.data, currentCharacter.length, 100, 0);
+        // Character (center current PNG horizontally)
+        int characterX = 100;
+        if (currentCharacter.data != nullptr && currentCharacter.length >= 24) {
+          const uint8_t* png = currentCharacter.data;
+          const int characterWidth = (int(png[16]) << 24) | (int(png[17]) << 16) | (int(png[18]) << 8) | int(png[19]);
+          if (characterWidth > 0) {
+            characterX = (M5Cardputer.Display.width() - characterWidth) / 2;
+          }
+        }
+        M5Cardputer.Display.drawPng(currentCharacter.data, currentCharacter.length, characterX, 0);
 
         // Helper text
         drawHelper(pfcHelperText);


### PR DESCRIPTION
### Motivation
- Center the currently displayed `currentCharacter` PNG when `currentState` is `PFC_GAME9` to improve visual alignment instead of using a fixed X offset.

### Description
- In `drawOverlay` under `case PFC_GAME9` compute `characterX` by reading the PNG width from the in-memory buffer (`currentCharacter.data` bytes 16-19) and center it with `characterX = (M5Cardputer.Display.width() - characterWidth) / 2`.
- Add defensive checks for `currentCharacter.data != nullptr` and `currentCharacter.length >= 24`, and keep a fallback of `characterX = 100` when image metadata is unavailable.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15854c9cb48321a6d5429e9d17063c)