### PR TITLE
Cook with Natsumi: fridge recipe prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Manage the daily life and artistic career of Natsumi Hasegawa, an aspiring Japan
   - [STATS](#stats)
   - [INVENTORY](#inventory-1)
   - [FOOD](#food)
-    - [FRIDGE](#fridge)
+    - [COOKING](#cooking)
     - [RESTAURANT](#restaurant)
     - [ORDER](#order)
     - [CONBINI](#conbini)
@@ -326,9 +326,32 @@ Opens the [Inventory](#inventory)
 
 Gives access to the food menu.
 
-#### FRIDGE
+#### COOKING
 
-Open the fridge and pick one food item to eat.
+Cook at home with ingredients stocked in the fridge. Use this option when Natsumi is hungry and you want to prepare a meal from the food bought at ConbiMart or won during events.
+
+How to cook:
+
+* Open **FOOD → COOKING**.
+* Move the cursor with the arrow keys, or with **W/A/S/D**.
+* Press **ENTER** to add or remove the highlighted fridge item from the current recipe.
+* Pick **2 to 4 ingredients**. Selected ingredients are marked on the cooking grid.
+* Green-highlighted ingredients can combine with the current selection.
+* Press **SPACE** to cook the selected recipe. Cooking consumes one of each selected ingredient and raises Hunger by 1, up to the maximum of 4.
+* If the selected ingredients do not match a known recipe while a known recipe is available, the game rejects the mix. If no known recipe can be made from the fridge stock, a generic **Pantry Snack** can still be cooked so Natsumi is not blocked from eating.
+
+Available recipes:
+
+| RECIPE | INGREDIENTS |
+|--------|-------------|
+| Avocado Toast | Bread, Avocado |
+| Egg Toast | Bread, Fried egg |
+| Banana Milk | Banana, Milk |
+| Strawberry Milk | Strawberries, Milk |
+| Avocado Egg Toast | Bread, Avocado, Fried egg |
+| Meat Veggie Plate | Meat, Broccoli, Carrot |
+| Natsumi Bento | Maki, Fried egg, Broccoli, Carrot |
+| Fruit Parfait | Milk, Strawberries, Banana, Biscuit |
 
 Shortcut: 2, 0
 

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -340,6 +340,18 @@ struct CookRecipe {
   FoodId ingredients[4];
 };
 
+const CookRecipe cookRecipes[] = {
+  {"Avocado Toast", 2, {FOOD_ID_BREAD, FOOD_ID_AVOCADO, FOOD_ID_NONE, FOOD_ID_NONE}},
+  {"Egg Toast", 2, {FOOD_ID_BREAD, FOOD_ID_FRIED_EGG, FOOD_ID_NONE, FOOD_ID_NONE}},
+  {"Banana Milk", 2, {FOOD_ID_BANANA, FOOD_ID_MILK, FOOD_ID_NONE, FOOD_ID_NONE}},
+  {"Strawberry Milk", 2, {FOOD_ID_STRAWBERRIES, FOOD_ID_MILK, FOOD_ID_NONE, FOOD_ID_NONE}},
+  {"Avocado Egg Toast", 3, {FOOD_ID_BREAD, FOOD_ID_AVOCADO, FOOD_ID_FRIED_EGG, FOOD_ID_NONE}},
+  {"Meat Veggie Plate", 3, {FOOD_ID_MEAT, FOOD_ID_BROCCOLI, FOOD_ID_CARROT, FOOD_ID_NONE}},
+  {"Natsumi Bento", 4, {FOOD_ID_MAKI, FOOD_ID_FRIED_EGG, FOOD_ID_BROCCOLI, FOOD_ID_CARROT}},
+  {"Fruit Parfait", 4, {FOOD_ID_MILK, FOOD_ID_STRAWBERRIES, FOOD_ID_BANANA, FOOD_ID_BISCUIT}}
+};
+const uint8_t cookRecipeCount = sizeof(cookRecipes) / sizeof(cookRecipes[0]);
+
 String selectedFood = "None";
 
 std::vector<FoodDisplayItem> foodGridItems;
@@ -8017,19 +8029,75 @@ bool toggleRecipeIngredient(const FoodDisplayItem &item) {
   return true;
 }
 
-const CookRecipe* findMatchingRecipe() {
-  static const CookRecipe recipes[] = {
-    {"Avocado Toast", 2, {FOOD_ID_BREAD, FOOD_ID_AVOCADO, FOOD_ID_NONE, FOOD_ID_NONE}},
-    {"Egg Toast", 2, {FOOD_ID_BREAD, FOOD_ID_FRIED_EGG, FOOD_ID_NONE, FOOD_ID_NONE}},
-    {"Banana Milk", 2, {FOOD_ID_BANANA, FOOD_ID_MILK, FOOD_ID_NONE, FOOD_ID_NONE}},
-    {"Strawberry Milk", 2, {FOOD_ID_STRAWBERRIES, FOOD_ID_MILK, FOOD_ID_NONE, FOOD_ID_NONE}},
-    {"Avocado Egg Toast", 3, {FOOD_ID_BREAD, FOOD_ID_AVOCADO, FOOD_ID_FRIED_EGG, FOOD_ID_NONE}},
-    {"Meat Veggie Plate", 3, {FOOD_ID_MEAT, FOOD_ID_BROCCOLI, FOOD_ID_CARROT, FOOD_ID_NONE}},
-    {"Natsumi Bento", 4, {FOOD_ID_MAKI, FOOD_ID_FRIED_EGG, FOOD_ID_BROCCOLI, FOOD_ID_CARROT}},
-    {"Fruit Parfait", 4, {FOOD_ID_MILK, FOOD_ID_STRAWBERRIES, FOOD_ID_BANANA, FOOD_ID_BISCUIT}}
-  };
+int* getFridgeQuantityPtr(FoodId id) {
+  switch (id) {
+    case FOOD_ID_RED_APPLE: return &fridge.redApple;
+    case FOOD_ID_GREEN_APPLE: return &fridge.greenApple;
+    case FOOD_ID_AVOCADO: return &fridge.avocado;
+    case FOOD_ID_BREAD: return &fridge.bread;
+    case FOOD_ID_BANANA: return &fridge.banana;
+    case FOOD_ID_BROCCOLI: return &fridge.broccoli;
+    case FOOD_ID_SWEETS: return &fridge.sweets;
+    case FOOD_ID_CARROT: return &fridge.carrot;
+    case FOOD_ID_MEAT: return &fridge.meat;
+    case FOOD_ID_COCONUT: return &fridge.coconut;
+    case FOOD_ID_COCONUT_JUICE: return &fridge.coconutJuice;
+    case FOOD_ID_COFFEE: return &fridge.coffee;
+    case FOOD_ID_BISCUIT: return &fridge.biscuits;
+    case FOOD_ID_CORN: return &fridge.corn;
+    case FOOD_ID_CROISSANT: return &fridge.croissant;
+    case FOOD_ID_FRIED_EGG: return &fridge.friedEgg;
+    case FOOD_ID_GRAPE: return &fridge.grapes;
+    case FOOD_ID_KIWI: return &fridge.kiwi;
+    case FOOD_ID_MILK: return &fridge.milk;
+    case FOOD_ID_ORANGE: return &fridge.orange;
+    case FOOD_ID_PEACH: return &fridge.peach;
+    case FOOD_ID_PEAR: return &fridge.pear;
+    case FOOD_ID_STRAWBERRIES: return &fridge.strawberries;
+    case FOOD_ID_MAKI: return &fridge.maki;
+    case FOOD_ID_SUSHI: return &fridge.sushi;
+    case FOOD_ID_WATERMELON: return &fridge.watermelon;
+    case FOOD_ID_NONE: return nullptr;
+  }
+  return nullptr;
+}
 
-  for (const auto &recipe : recipes) {
+bool canMakeRecipeFromFridge(const CookRecipe &recipe) {
+  for (uint8_t i = 0; i < recipe.ingredientCount; i++) {
+    int* quantityPtr = getFridgeQuantityPtr(recipe.ingredients[i]);
+    if (!quantityPtr || *quantityPtr <= 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool hasCookableRecipe() {
+  for (uint8_t i = 0; i < cookRecipeCount; i++) {
+    if (canMakeRecipeFromFridge(cookRecipes[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool isCookableRecipeIngredient(FoodId id) {
+  for (uint8_t i = 0; i < cookRecipeCount; i++) {
+    if (!canMakeRecipeFromFridge(cookRecipes[i])) {
+      continue;
+    }
+    for (uint8_t j = 0; j < cookRecipes[i].ingredientCount; j++) {
+      if (cookRecipes[i].ingredients[j] == id) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+const CookRecipe* findMatchingRecipe() {
+  for (uint8_t recipeIndex = 0; recipeIndex < cookRecipeCount; recipeIndex++) {
+    const CookRecipe &recipe = cookRecipes[recipeIndex];
     if (recipe.ingredientCount != recipeSelectionCount) {
       continue;
     }
@@ -8050,7 +8118,7 @@ const CookRecipe* findMatchingRecipe() {
     }
 
     if (matched) {
-      return &recipe;
+      return &cookRecipes[recipeIndex];
     }
   }
 
@@ -8073,10 +8141,16 @@ bool cookSelectedRecipe() {
   }
 
   const CookRecipe* recipe = findMatchingRecipe();
+  bool pantryFallback = false;
   if (!recipe) {
-    // Safer prototype behavior: reject unknown mixes without consuming scarce fridge stock.
-    showToast("No recipe yet");
-    return false;
+    if (hasCookableRecipe()) {
+      // Safer prototype behavior: reject unknown mixes while a known recipe is available.
+      showToast("No recipe yet");
+      return false;
+    }
+    // If the fridge cannot make any known recipe, allow a generic snack so the
+    // player is not blocked from feeding Natsumi by the prototype recipe list.
+    pantryFallback = true;
   }
 
   for (uint8_t i = 0; i < recipeSelectionCount; i++) {
@@ -8097,7 +8171,7 @@ bool cookSelectedRecipe() {
   saveRequired = true;
   FoodDisplayItem* previewItem = findFoodGridItem(recipeSelection[0]);
   selectedFood = previewItem ? String(previewItem->label) : "None";
-  showToast(String(recipe->name));
+  showToast(pantryFallback ? String("Pantry Snack") : String(recipe->name));
   clearFoodGrid();
   overlayActive = false;
   changeState(0, FOOD_COOK2, 0);
@@ -8150,6 +8224,11 @@ void prepareFoodGrid() {
   }
 
   std::sort(options.begin(), options.end(), [](const FoodDisplayItem &a, const FoodDisplayItem &b) {
+    bool aCookable = isCookableRecipeIngredient(a.id);
+    bool bCookable = isCookableRecipeIngredient(b.id);
+    if (aCookable != bCookable) {
+      return aCookable;
+    }
     return a.quantity > b.quantity;
   });
 

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -349,6 +349,8 @@ int inventoryPageIndex = 0;
 FoodId recipeSelection[4] = {FOOD_ID_NONE, FOOD_ID_NONE, FOOD_ID_NONE, FOOD_ID_NONE};
 uint8_t recipeSelectionCount = 0;
 
+void clearFoodGrid();
+
 struct ConbimartItem {
   const char* label;
   int price;
@@ -7974,8 +7976,6 @@ bool preloadFoodIcon(FoodDisplayItem &item) {
   String altPath = String("/idolnat/sprites/food/") + String(strrchr(item.iconPath, '/') ? strrchr(item.iconPath, '/') + 1 : item.iconPath);
   return preloadImage(altPath.c_str(), item.icon);
 }
-
-void clearFoodGrid();
 
 void resetRecipeSelection() {
   for (uint8_t i = 0; i < 4; i++) {

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -8095,6 +8095,50 @@ bool isCookableRecipeIngredient(FoodId id) {
   return false;
 }
 
+bool recipeContainsIngredient(const CookRecipe &recipe, FoodId id) {
+  for (uint8_t i = 0; i < recipe.ingredientCount; i++) {
+    if (recipe.ingredients[i] == id) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool recipeContainsCurrentSelection(const CookRecipe &recipe) {
+  for (uint8_t i = 0; i < recipeSelectionCount; i++) {
+    if (!recipeContainsIngredient(recipe, recipeSelection[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool isPotentialRecipeIngredient(FoodId id) {
+  if (isRecipeItemSelected(id)) {
+    return false;
+  }
+
+  int* quantityPtr = getFridgeQuantityPtr(id);
+  if (!quantityPtr || *quantityPtr <= 0 || recipeSelectionCount >= 4) {
+    return false;
+  }
+
+  if (!hasCookableRecipe()) {
+    return true;
+  }
+
+  for (uint8_t i = 0; i < cookRecipeCount; i++) {
+    const CookRecipe &recipe = cookRecipes[i];
+    if (!canMakeRecipeFromFridge(recipe) || recipe.ingredientCount <= recipeSelectionCount) {
+      continue;
+    }
+    if (recipeContainsCurrentSelection(recipe) && recipeContainsIngredient(recipe, id)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 const CookRecipe* findMatchingRecipe() {
   for (uint8_t recipeIndex = 0; recipeIndex < cookRecipeCount; recipeIndex++) {
     const CookRecipe &recipe = cookRecipes[recipeIndex];
@@ -8253,6 +8297,7 @@ void drawFoodGrid(const std::vector<FoodDisplayItem> &items, int selectedIndex) 
   const uint16_t shadowColor = M5Cardputer.Display.color565(10, 14, 32);
   const uint16_t panelColor = M5Cardputer.Display.color565(16, 24, 44);
   const uint16_t accentColor = M5Cardputer.Display.color565(120, 200, 255);
+  const uint16_t combineColor = M5Cardputer.Display.color565(80, 235, 150);
   const uint16_t cellColor = M5Cardputer.Display.color565(28, 40, 64);
   const uint16_t highlightColor = M5Cardputer.Display.color565(60, 90, 140);
 
@@ -8278,13 +8323,16 @@ void drawFoodGrid(const std::vector<FoodDisplayItem> &items, int selectedIndex) 
     int cellY = panelY + headerHeight + padding + row * (cellH + padding);
     bool selected = (static_cast<int>(i) == selectedIndex);
     bool ingredientSelected = isRecipeItemSelected(items[i].id);
+    bool combineCandidate = isPotentialRecipeIngredient(items[i].id);
     uint16_t fill = selected ? highlightColor : cellColor;
-    uint16_t border = ingredientSelected ? YELLOW : accentColor;
+    uint16_t border = ingredientSelected ? YELLOW : (combineCandidate ? combineColor : accentColor);
 
     M5Cardputer.Display.fillRoundRect(cellX, cellY, cellW, cellH, 6, fill);
     M5Cardputer.Display.drawRoundRect(cellX, cellY, cellW, cellH, 6, border);
     if (ingredientSelected) {
       M5Cardputer.Display.fillCircle(cellX + cellW - 7, cellY + 7, 4, YELLOW);
+    } else if (combineCandidate) {
+      M5Cardputer.Display.fillCircle(cellX + cellW - 7, cellY + 7, 3, combineColor);
     }
 
     int iconOffset = (cellW - 32) / 2;
@@ -8302,7 +8350,7 @@ void drawFoodGrid(const std::vector<FoodDisplayItem> &items, int selectedIndex) 
   }
 
   M5Cardputer.Display.fillRect(0, 125, 240, 10, BLACK);
-  drawText("ENTER: Add/Remove  SPACE: Cook  ESC", 120, 131, true, WHITE, 1);
+  drawText("Green: Combines  ENTER +/-  SPACE Cook", 120, 131, true, WHITE, 1);
 }
 
 int getConbimartTotal() {

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -295,12 +295,49 @@ struct ImageBuffer {
   size_t length = 0;
 };
 
+enum FoodId : uint8_t {
+  FOOD_ID_RED_APPLE,
+  FOOD_ID_GREEN_APPLE,
+  FOOD_ID_AVOCADO,
+  FOOD_ID_BREAD,
+  FOOD_ID_BANANA,
+  FOOD_ID_BROCCOLI,
+  FOOD_ID_SWEETS,
+  FOOD_ID_CARROT,
+  FOOD_ID_MEAT,
+  FOOD_ID_COCONUT,
+  FOOD_ID_COCONUT_JUICE,
+  FOOD_ID_COFFEE,
+  FOOD_ID_BISCUIT,
+  FOOD_ID_CORN,
+  FOOD_ID_CROISSANT,
+  FOOD_ID_FRIED_EGG,
+  FOOD_ID_GRAPE,
+  FOOD_ID_KIWI,
+  FOOD_ID_MILK,
+  FOOD_ID_ORANGE,
+  FOOD_ID_PEACH,
+  FOOD_ID_PEAR,
+  FOOD_ID_STRAWBERRIES,
+  FOOD_ID_MAKI,
+  FOOD_ID_SUSHI,
+  FOOD_ID_WATERMELON,
+  FOOD_ID_NONE
+};
+
 struct FoodDisplayItem {
+  FoodId id;
   const char* label;
   const char* iconPath;
   int* quantityPtr;
   int quantity;
   ImageBuffer icon;
+};
+
+struct CookRecipe {
+  const char* name;
+  uint8_t ingredientCount;
+  FoodId ingredients[4];
 };
 
 String selectedFood = "None";
@@ -309,6 +346,8 @@ std::vector<FoodDisplayItem> foodGridItems;
 int foodSelectionIndex = 0;
 bool foodGridInitialized = false;
 int inventoryPageIndex = 0;
+FoodId recipeSelection[4] = {FOOD_ID_NONE, FOOD_ID_NONE, FOOD_ID_NONE, FOOD_ID_NONE};
+uint8_t recipeSelectionCount = 0;
 
 struct ConbimartItem {
   const char* label;
@@ -7936,44 +7975,174 @@ bool preloadFoodIcon(FoodDisplayItem &item) {
   return preloadImage(altPath.c_str(), item.icon);
 }
 
+void clearFoodGrid();
+
+void resetRecipeSelection() {
+  for (uint8_t i = 0; i < 4; i++) {
+    recipeSelection[i] = FOOD_ID_NONE;
+  }
+  recipeSelectionCount = 0;
+}
+
+int findRecipeSelection(FoodId id) {
+  for (uint8_t i = 0; i < recipeSelectionCount; i++) {
+    if (recipeSelection[i] == id) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+bool isRecipeItemSelected(FoodId id) {
+  return findRecipeSelection(id) >= 0;
+}
+
+bool toggleRecipeIngredient(const FoodDisplayItem &item) {
+  int selectedIndex = findRecipeSelection(item.id);
+  if (selectedIndex >= 0) {
+    for (uint8_t i = selectedIndex; i + 1 < recipeSelectionCount; i++) {
+      recipeSelection[i] = recipeSelection[i + 1];
+    }
+    recipeSelection[recipeSelectionCount - 1] = FOOD_ID_NONE;
+    recipeSelectionCount--;
+    return true;
+  }
+
+  if (recipeSelectionCount >= 4 || *(item.quantityPtr) <= 0) {
+    return false;
+  }
+
+  recipeSelection[recipeSelectionCount] = item.id;
+  recipeSelectionCount++;
+  return true;
+}
+
+const CookRecipe* findMatchingRecipe() {
+  static const CookRecipe recipes[] = {
+    {"Avocado Toast", 2, {FOOD_ID_BREAD, FOOD_ID_AVOCADO, FOOD_ID_NONE, FOOD_ID_NONE}},
+    {"Egg Toast", 2, {FOOD_ID_BREAD, FOOD_ID_FRIED_EGG, FOOD_ID_NONE, FOOD_ID_NONE}},
+    {"Banana Milk", 2, {FOOD_ID_BANANA, FOOD_ID_MILK, FOOD_ID_NONE, FOOD_ID_NONE}},
+    {"Strawberry Milk", 2, {FOOD_ID_STRAWBERRIES, FOOD_ID_MILK, FOOD_ID_NONE, FOOD_ID_NONE}},
+    {"Avocado Egg Toast", 3, {FOOD_ID_BREAD, FOOD_ID_AVOCADO, FOOD_ID_FRIED_EGG, FOOD_ID_NONE}},
+    {"Meat Veggie Plate", 3, {FOOD_ID_MEAT, FOOD_ID_BROCCOLI, FOOD_ID_CARROT, FOOD_ID_NONE}},
+    {"Natsumi Bento", 4, {FOOD_ID_MAKI, FOOD_ID_FRIED_EGG, FOOD_ID_BROCCOLI, FOOD_ID_CARROT}},
+    {"Fruit Parfait", 4, {FOOD_ID_MILK, FOOD_ID_STRAWBERRIES, FOOD_ID_BANANA, FOOD_ID_BISCUIT}}
+  };
+
+  for (const auto &recipe : recipes) {
+    if (recipe.ingredientCount != recipeSelectionCount) {
+      continue;
+    }
+
+    bool matched = true;
+    for (uint8_t i = 0; i < recipeSelectionCount; i++) {
+      bool ingredientFound = false;
+      for (uint8_t j = 0; j < recipe.ingredientCount; j++) {
+        if (recipeSelection[i] == recipe.ingredients[j]) {
+          ingredientFound = true;
+          break;
+        }
+      }
+      if (!ingredientFound) {
+        matched = false;
+        break;
+      }
+    }
+
+    if (matched) {
+      return &recipe;
+    }
+  }
+
+  return nullptr;
+}
+
+FoodDisplayItem* findFoodGridItem(FoodId id) {
+  for (auto &item : foodGridItems) {
+    if (item.id == id) {
+      return &item;
+    }
+  }
+  return nullptr;
+}
+
+bool cookSelectedRecipe() {
+  if (recipeSelectionCount < 2 || recipeSelectionCount > 4) {
+    showToast("Pick 2-4 items");
+    return false;
+  }
+
+  const CookRecipe* recipe = findMatchingRecipe();
+  if (!recipe) {
+    // Safer prototype behavior: reject unknown mixes without consuming scarce fridge stock.
+    showToast("No recipe yet");
+    return false;
+  }
+
+  for (uint8_t i = 0; i < recipeSelectionCount; i++) {
+    FoodDisplayItem* item = findFoodGridItem(recipeSelection[i]);
+    if (!item || *(item->quantityPtr) <= 0) {
+      showToast("Missing ingredient");
+      return false;
+    }
+  }
+
+  for (uint8_t i = 0; i < recipeSelectionCount; i++) {
+    FoodDisplayItem* item = findFoodGridItem(recipeSelection[i]);
+    *(item->quantityPtr) -= 1;
+    item->quantity = *(item->quantityPtr);
+  }
+
+  natsumi.hunger = std::min(4, natsumi.hunger + 1);
+  saveRequired = true;
+  FoodDisplayItem* previewItem = findFoodGridItem(recipeSelection[0]);
+  selectedFood = previewItem ? String(previewItem->label) : "None";
+  showToast(String(recipe->name));
+  clearFoodGrid();
+  overlayActive = false;
+  changeState(0, FOOD_COOK2, 0);
+  return true;
+}
+
 void clearFoodGrid() {
   for (auto &item : foodGridItems) {
     unloadImage(item.icon);
   }
   foodGridItems.clear();
   foodGridInitialized = false;
+  resetRecipeSelection();
 }
 
 void prepareFoodGrid() {
   clearFoodGrid();
 
   std::vector<FoodDisplayItem> options = {
-    {"Red apple", "/idolnat/sprites/food_001.png", &fridge.redApple},
-    {"Green apple", "/idolnat/sprites/food_002.png", &fridge.greenApple},
-    {"Avocado", "/idolnat/sprites/food_003.png", &fridge.avocado},
-    {"Bread", "/idolnat/sprites/food_005.png", &fridge.bread},
-    {"Banana", "/idolnat/sprites/food_008.png", &fridge.banana},
-    {"Broccoli", "/idolnat/sprites/food_015.png", &fridge.broccoli},
-    {"Sweets", "/idolnat/sprites/food_021.png", &fridge.sweets},
-    {"Carrot", "/idolnat/sprites/food_028.png", &fridge.carrot},
-    {"Meat", "/idolnat/sprites/food_033.png", &fridge.meat},
-    {"Coconut", "/idolnat/sprites/food_038.png", &fridge.coconut},
-    {"Coconut juice", "/idolnat/sprites/food_039.png", &fridge.coconutJuice},
-    {"Coffee", "/idolnat/sprites/food_041.png", &fridge.coffee},
-    {"Biscuit", "/idolnat/sprites/food_044.png", &fridge.biscuits},
-    {"Corn", "/idolnat/sprites/food_045.png", &fridge.corn},
-    {"Croissant", "/idolnat/sprites/food_046.png", &fridge.croissant},
-    {"Fried egg", "/idolnat/sprites/food_053.png", &fridge.friedEgg},
-    {"Grape", "/idolnat/sprites/food_061.png", &fridge.grapes},
-    {"Kiwi", "/idolnat/sprites/food_081.png", &fridge.kiwi},
-    {"Milk", "/idolnat/sprites/food_092.png", &fridge.milk},
-    {"Orange", "/idolnat/sprites/food_109.png", &fridge.orange},
-    {"Peach", "/idolnat/sprites/food_111.png", &fridge.peach},
-    {"Pear", "/idolnat/sprites/food_113.png", &fridge.pear},
-    {"Strawberries", "/idolnat/sprites/food_149.png", &fridge.strawberries},
-    {"Maki", "/idolnat/sprites/food_150.png", &fridge.maki},
-    {"Sushi", "/idolnat/sprites/food_154.png", &fridge.sushi},
-    {"Watermelon", "/idolnat/sprites/food_168.png", &fridge.watermelon}
+    {FOOD_ID_RED_APPLE, "Red apple", "/idolnat/sprites/food_001.png", &fridge.redApple},
+    {FOOD_ID_GREEN_APPLE, "Green apple", "/idolnat/sprites/food_002.png", &fridge.greenApple},
+    {FOOD_ID_AVOCADO, "Avocado", "/idolnat/sprites/food_003.png", &fridge.avocado},
+    {FOOD_ID_BREAD, "Bread", "/idolnat/sprites/food_005.png", &fridge.bread},
+    {FOOD_ID_BANANA, "Banana", "/idolnat/sprites/food_008.png", &fridge.banana},
+    {FOOD_ID_BROCCOLI, "Broccoli", "/idolnat/sprites/food_015.png", &fridge.broccoli},
+    {FOOD_ID_SWEETS, "Sweets", "/idolnat/sprites/food_021.png", &fridge.sweets},
+    {FOOD_ID_CARROT, "Carrot", "/idolnat/sprites/food_028.png", &fridge.carrot},
+    {FOOD_ID_MEAT, "Meat", "/idolnat/sprites/food_033.png", &fridge.meat},
+    {FOOD_ID_COCONUT, "Coconut", "/idolnat/sprites/food_038.png", &fridge.coconut},
+    {FOOD_ID_COCONUT_JUICE, "Coconut juice", "/idolnat/sprites/food_039.png", &fridge.coconutJuice},
+    {FOOD_ID_COFFEE, "Coffee", "/idolnat/sprites/food_041.png", &fridge.coffee},
+    {FOOD_ID_BISCUIT, "Biscuit", "/idolnat/sprites/food_044.png", &fridge.biscuits},
+    {FOOD_ID_CORN, "Corn", "/idolnat/sprites/food_045.png", &fridge.corn},
+    {FOOD_ID_CROISSANT, "Croissant", "/idolnat/sprites/food_046.png", &fridge.croissant},
+    {FOOD_ID_FRIED_EGG, "Fried egg", "/idolnat/sprites/food_053.png", &fridge.friedEgg},
+    {FOOD_ID_GRAPE, "Grape", "/idolnat/sprites/food_061.png", &fridge.grapes},
+    {FOOD_ID_KIWI, "Kiwi", "/idolnat/sprites/food_081.png", &fridge.kiwi},
+    {FOOD_ID_MILK, "Milk", "/idolnat/sprites/food_092.png", &fridge.milk},
+    {FOOD_ID_ORANGE, "Orange", "/idolnat/sprites/food_109.png", &fridge.orange},
+    {FOOD_ID_PEACH, "Peach", "/idolnat/sprites/food_111.png", &fridge.peach},
+    {FOOD_ID_PEAR, "Pear", "/idolnat/sprites/food_113.png", &fridge.pear},
+    {FOOD_ID_STRAWBERRIES, "Strawberries", "/idolnat/sprites/food_149.png", &fridge.strawberries},
+    {FOOD_ID_MAKI, "Maki", "/idolnat/sprites/food_150.png", &fridge.maki},
+    {FOOD_ID_SUSHI, "Sushi", "/idolnat/sprites/food_154.png", &fridge.sushi},
+    {FOOD_ID_WATERMELON, "Watermelon", "/idolnat/sprites/food_168.png", &fridge.watermelon}
   };
 
   for (auto &option : options) {
@@ -8015,7 +8184,7 @@ void drawFoodGrid(const std::vector<FoodDisplayItem> &items, int selectedIndex) 
   M5Cardputer.Display.setTextDatum(middle_center);
   M5Cardputer.Display.setTextSize(1);
   M5Cardputer.Display.setTextColor(WHITE, panelColor);
-  M5Cardputer.Display.drawString("What\'s in the fridge?", panelX + panelW / 2, panelY + headerHeight / 2 + 1);
+  M5Cardputer.Display.drawString(String("Cook with Natsumi ") + String(recipeSelectionCount) + String("/4"), panelX + panelW / 2, panelY + headerHeight / 2 + 1);
 
   const int cols = 4;
   const int rows = 2;
@@ -8029,10 +8198,15 @@ void drawFoodGrid(const std::vector<FoodDisplayItem> &items, int selectedIndex) 
     int cellX = panelX + padding + col * (cellW + padding);
     int cellY = panelY + headerHeight + padding + row * (cellH + padding);
     bool selected = (static_cast<int>(i) == selectedIndex);
+    bool ingredientSelected = isRecipeItemSelected(items[i].id);
     uint16_t fill = selected ? highlightColor : cellColor;
+    uint16_t border = ingredientSelected ? YELLOW : accentColor;
 
     M5Cardputer.Display.fillRoundRect(cellX, cellY, cellW, cellH, 6, fill);
-    M5Cardputer.Display.drawRoundRect(cellX, cellY, cellW, cellH, 6, accentColor);
+    M5Cardputer.Display.drawRoundRect(cellX, cellY, cellW, cellH, 6, border);
+    if (ingredientSelected) {
+      M5Cardputer.Display.fillCircle(cellX + cellW - 7, cellY + 7, 4, YELLOW);
+    }
 
     int iconOffset = (cellW - 32) / 2;
     if (items[i].icon.data && items[i].icon.length > 0) {
@@ -8049,7 +8223,7 @@ void drawFoodGrid(const std::vector<FoodDisplayItem> &items, int selectedIndex) 
   }
 
   M5Cardputer.Display.fillRect(0, 125, 240, 10, BLACK);
-  drawText("Arrows: Move  ENTER: Eat  ESC: Close", 120, 131, true, WHITE, 1);
+  drawText("ENTER: Add/Remove  SPACE: Cook  ESC", 120, 131, true, WHITE, 1);
 }
 
 int getConbimartTotal() {
@@ -9285,25 +9459,26 @@ void cookFood() {
             changeState(0, HOME_LOOP, 0);
             return;
             break;
-          // ENTER
-          case 13: case 40: case ' ':
+          // ENTER toggles the highlighted fridge item in the current recipe.
+          case 13: case 40:
             if (!foodGridItems.empty()) {
               FoodDisplayItem &choice = foodGridItems[foodSelectionIndex];
-              if (*(choice.quantityPtr) > 0) {
-                *(choice.quantityPtr) -= 1;
-                choice.quantity = *(choice.quantityPtr);
-                if (natsumi.hunger < 4) {
-                  natsumi.hunger += 1;
-                  saveRequired = true;
-                  // isNatsumiHappy = true;
-                }
-                showToast("Having " + String(choice.label));
-                clearFoodGrid();
-                overlayActive = false;
-                selectedFood = String(choice.label);
-                changeState(0, FOOD_COOK2, 0);
+              if (toggleRecipeIngredient(choice)) {
+                l5NeedsRedraw = true;
+              } else if (*(choice.quantityPtr) <= 0) {
+                showToast("No stock");
+              } else {
+                showToast("Max 4 items");
               }
             }
+            return;
+            break;
+          // SPACE cooks the current 2-4 ingredient selection.
+          case ' ':
+            if (cookSelectedRecipe()) {
+              return;
+            }
+            l5NeedsRedraw = true;
             return;
             break;
         }


### PR DESCRIPTION
### Motivation
- Provide a small recipe-combination prototype that lets the player pick 2–4 fridge items to cook, replacing the single-item eat flow while preserving the existing fridge inventory, save format, and keyboard navigation.

### Description
- Add a compact `FoodId` enum, `CookRecipe` struct and a 4-slot `recipeSelection` buffer plus helper functions (`resetRecipeSelection`, `findRecipeSelection`, `toggleRecipeIngredient`, `findMatchingRecipe`, `findFoodGridItem`, `cookSelectedRecipe`) implemented with static arrays to keep RAM usage low.
- Integrate IDs into `foodGridItems` and update `drawFoodGrid` to show selected-ingredient markers and a header that reports the current selection count, while `prepareFoodGrid` still uses existing fridge quantity pointers and preloads icons.
- Change `cookFood` input handling to preserve arrow/WASD movement and ESC behavior, use ENTER to add/remove the highlighted fridge item to/from the current recipe, and use SPACE to attempt cooking (requires 2–4 ingredients); on a matched recipe the code consumes one unit per ingredient, increases `natsumi.hunger`, shows a toast with the recipe name, and transitions to the existing `FOOD_COOK2` preview.
- Add a small static recipe table with the requested combinations (Avocado Toast, Egg Toast, Banana Milk, Strawberry Milk, Avocado Egg Toast, Meat Veggie Plate, Natsumi Bento, Fruit Parfait) and choose safer prototype behavior for unknown mixes by rejecting them without consuming stock, with clear comments stating this decision; no new image assets or save-format changes were introduced.

### Testing
- Ran `git diff --check` which completed with no diff-check errors.
- Checked for local toolchains with `command -v arduino-cli` and `command -v pio` and neither tool is available in this environment so a full sketch compile could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d5d6056e8832193e79da2d93fc38f)