### PR TITLE
Allow cooking/eating single food items (1-4 ingredients)

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,9 +335,9 @@ How to cook:
 * Open **FOOD → COOKING**.
 * Move the cursor with the arrow keys, or with **W/A/S/D**.
 * Press **ENTER** to add or remove the highlighted fridge item from the current recipe.
-* Pick **2 to 4 ingredients**. Selected ingredients are marked on the cooking grid.
+* Pick **1 to 4 ingredients**. Selected ingredients are marked on the cooking grid.
 * Green-highlighted ingredients can combine with the current selection.
-* Press **SPACE** to cook the selected recipe. Cooking consumes one of each selected ingredient and raises Hunger by 1, up to the maximum of 4.
+* Press **SPACE** to cook/eat the selected recipe. Cooking consumes one of each selected ingredient and raises Hunger by 1, up to the maximum of 4.
 * If the selected ingredients do not match a known recipe while a known recipe is available, the game rejects the mix. If no known recipe can be made from the fridge stock, a generic **Pantry Snack** can still be cooked so Natsumi is not blocked from eating.
 
 Available recipes:

--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -8581,8 +8581,8 @@ FoodDisplayItem* findFoodGridItem(FoodId id) {
 }
 
 bool cookSelectedRecipe() {
-  if (recipeSelectionCount < 2 || recipeSelectionCount > 4) {
-    showToast("Pick 2-4 items");
+  if (recipeSelectionCount < 1 || recipeSelectionCount > 4) {
+    showToast("Pick 1-4 items");
     return false;
   }
 
@@ -8753,7 +8753,7 @@ void drawFoodGrid(const std::vector<FoodDisplayItem> &items, int selectedIndex) 
   }
 
   M5Cardputer.Display.fillRect(0, 125, 240, 10, BLACK);
-  drawText("Green: Combines  ENTER +/-  SPACE Cook", 120, 131, true, WHITE, 1);
+  drawText("Green: Can cook  ENTER +/-  SPACE Eat", 120, 131, true, WHITE, 1);
 }
 
 int getConbimartTotal() {
@@ -10018,7 +10018,7 @@ void cookFood() {
             }
             return;
             break;
-          // SPACE cooks the current 2-4 ingredient selection.
+          // SPACE cooks the current 1-4 ingredient selection.
           case ' ':
             if (cookSelectedRecipe()) {
               return;


### PR DESCRIPTION
### Motivation
- New per-ingredient `CookRecipe` entries require the cooking flow to accept single-item recipes so a single food can be cooked/eaten with `SPACE`.

### Description
- Relax the selection check in `cookSelectedRecipe()` to allow `1`–`4` items and update the on-screen helper and `SPACE` comment in `idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino`; update cooking instructions in `README.md` to `1-4` ingredients.

### Testing
- Ran `git diff --check` after the changes and no warnings were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36065551548321b06db505fbb3c789)