### PR TITLE
Apply cooking hunger bonus from ingredient count and display it in outcome

### DIFF
--- a/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
+++ b/idol_natsumi_v0_6_1012/idol_natsumi_v0_6_1012.ino
@@ -395,6 +395,7 @@ bool foodGridInitialized = false;
 int inventoryPageIndex = 0;
 FoodId recipeSelection[4] = {FOOD_ID_NONE, FOOD_ID_NONE, FOOD_ID_NONE, FOOD_ID_NONE};
 uint8_t recipeSelectionCount = 0;
+uint8_t lastCookHungerBonus = 0;
 
 void clearFoodGrid();
 
@@ -8627,8 +8628,8 @@ bool cookSelectedRecipe() {
     item->quantity = *(item->quantityPtr);
   }
 
-  // natsumi.hunger = 4;
-  natsumi.hunger += recipeSelectionCount;
+  lastCookHungerBonus = recipeSelectionCount;
+  natsumi.hunger += lastCookHungerBonus;
   if (natsumi.hunger > 4) {
     natsumi.hunger = 4;
   }
@@ -9326,7 +9327,7 @@ void drawOverlay() {
       case ACTION_OUTCOME:
         switch(previousState) {
           case FOOD_COOK2:
-            drawOutcome("+" + String(recipeSelectionCount), "Hunger");
+            drawOutcome("+" + String(lastCookHungerBonus), "Hunger");
             break;
           case FOOD_ORDER8:
             if (natsumi.grace < 4) {


### PR DESCRIPTION
### Motivation
- Make the hunger bonus applied when cooking depend on how many ingredients were used (1–4) and cap Natsumi's hunger at 4, and ensure the action outcome screen displays the correct bonus even though the recipe selection is cleared after cooking.

### Description
- Add a new `uint8_t lastCookHungerBonus` to store the hunger bonus prior to clearing the recipe selection. 
- In `cookSelectedRecipe()` set `lastCookHungerBonus = recipeSelectionCount`, add that amount to `natsumi.hunger`, and clamp `natsumi.hunger` to `4`.
- Update the action outcome branch for `FOOD_COOK2` to display `lastCookHungerBonus` instead of the (now-cleared) `recipeSelectionCount`.
- No other gameplay logic was changed.

### Testing
- Ran `git diff --check` to validate the diff format and whitespace; it succeeded. 
- Ran `rg -n "lastCookHungerBonus|natsumi\.hunger \+=|drawOutcome\(\"\+\" \+ String\(lastCookHungerBonus\)"` to verify the new symbol is used in the expected locations; it returned the updated occurrences.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fac5f7dc08321833dcf3100611227)